### PR TITLE
move to typenum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This project follows semantic versioning.
+
+### 0.5.0 (2015-12-02)
+- `[added]` This change log!
+- `[changed]` Use typenum instead of peano for faster and more complete type-level numbers. (#3)
+- `[added]` Re-export useful things from typenum so that crates downstream don't need to depend on it.
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@
   name = "dimensioned"
 
 [dependencies]
-  num = "0.1.27"
-  typenum = "1.0.1"
+  num = "0.1.28"
+  typenum = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@
   name = "dimensioned"
 
 [dependencies]
-  num = "*"
-  peano = "*"
+  num = "0.1.27"
+  typenum = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
   name = "dimensioned"
-  version = "0.4.0"
+  version = "0.5.0"
   authors = ["Paho Lurie-Gregg <paho@paholg.com>"]
   description = "Compile-time type checking of arbitrary unit systems."
   homepage = "http://paholg.com/project/dimensioned"

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -1,4 +1,4 @@
-extern crate peano;
+extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 

--- a/examples/vector3a.rs
+++ b/examples/vector3a.rs
@@ -4,7 +4,7 @@ extern crate dimensioned;
 
 use vector3a::Vector3;
 
-use peano::Same;
+use typenum::Same;
 use std::ops::{Mul};
 use dimensioned::si::{one, m, kg, s};
 use dimensioned::{Dim, Dimension};

--- a/examples/vector3a.rs
+++ b/examples/vector3a.rs
@@ -1,4 +1,4 @@
-extern crate peano;
+extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 

--- a/src/dimensioned.rs
+++ b/src/dimensioned.rs
@@ -9,8 +9,9 @@ module. They are `Dimension`, `Dimensionless`, and `DimToString`.
 */
 
 use typenum::Same;
-use typenum::consts::{P2, P3};
 use typenum::int::Integer;
+use typenum::consts::{P2, P3};
+
 use std::marker::PhantomData;
 
 use std::ops::{Add, Sub, Mul, Div, Neg, BitAnd, BitOr, BitXor, FnOnce, Not, Rem, Shl, Shr};
@@ -46,8 +47,14 @@ pub trait DimToString: Dimension {
 }
 
 /// This is the primary struct that users of this library will interact with.
-#[derive(Copy, Clone)]
 pub struct Dim<D: Dimension, V>(pub V, pub PhantomData<D>);
+
+use std::clone::Clone;
+use std::marker::Copy;
+impl<D: Dimension, V: Clone> Clone for Dim<D, V> {
+    fn clone(&self) -> Self { Dim::new(self.0.clone()) }
+}
+impl<D: Dimension, V: Copy> Copy for Dim<D, V> {}
 
 impl<D: Dimension, V> Dim<D, V> {
     /**
@@ -158,7 +165,7 @@ impl<D, V> Cbrt for Dim<D, V> where D: Dimension + Root<P3>, V: Float, <D as Roo
 **Root<Radicand>** is used for implementing general integer roots for types that don't
 `impl Float` and whose type signature changes when taking a root, such as `Dim<D, V>`.
 
-It uses typenum numbers to specify the degree.
+It uses type numbers to specify the degree.
 
 The syntax is a little bit weird and may be subject to change.
 */
@@ -197,7 +204,7 @@ impl<D, V, Degree> Root<Dim<D, V>> for Degree where D: Dimension + Root<Degree>,
 **Pow<Base>** is used for implementing general integer powers for types that don't `impl
 Float` and whose type signature changes when multiplying, such as `Dim<D, V>`.
 
-It uses typenum numbers to specify the degree.
+It uses type numbers to specify the degree.
 
 The syntax is a little bit weird and may be subject to change.
 */
@@ -276,8 +283,8 @@ one of:
 * `Mul`: Multiplies `Self` by `Self`. The same as `Pow<P2>`.
 * `Div`: Divides `Self` by `Self`. The same as `Pow<Zero>`.
 * `Recip`: Gives the reciprocal of `Self`.
-* `Pow<N>`: Raises `Self` to the exponent `N` where `N` is a Typenum number.
-* `Root<N>`: Takes the `N`th root of `Self` where `N` is a Typenum number.
+* `Pow<N>`: Raises `Self` to the exponent `N` where `N` is a type number.
+* `Root<N>`: Takes the `N`th root of `Self` where `N` is a type number.
 * `Sqrt`: Takes the square root of `Self`. The same as `Root<P2>`.
 * `Cbrt`: Takes the cube root of `Self`. The same as `Root<P3>`.
 

--- a/src/dimensioned.rs
+++ b/src/dimensioned.rs
@@ -6,11 +6,9 @@ many traits from `std` as generically as possible.
 Among the included traits in **dimensioned**, there are a few that are used solely to
 aid in generic programming and should not be implemented for anything outside this
 module. They are `Dimension`, `Dimensionless`, and `DimToString`.
-*/
+ */
 
-use typenum::Same;
-use typenum::int::Integer;
-use typenum::consts::{P2, P3};
+use {Same, Integer, P2, P3};
 
 use std::marker::PhantomData;
 
@@ -140,16 +138,12 @@ pub trait Cbrt {
     Take a cube root.
     # Example
     ```
-    # extern crate typenum;
-    # extern crate dimensioned;
     use dimensioned::si::m;
     use dimensioned::Cbrt;
 
-    # fn main() {
     let x = 2.0*m;
     let y = 8.0*m*m*m;
     assert_eq!(x, y.cbrt());
-    # }
     ```
      */
     fn cbrt(self) -> Self::Output;
@@ -176,18 +170,13 @@ pub trait Root<Radicand> {
     /**
     # Example
     ```
-    # extern crate typenum;
-    # extern crate dimensioned;
-
     use dimensioned::si::m;
     use dimensioned::Root;
-    use typenum::consts::P4;
+    use dimensioned::P4;
 
-    # fn main() {
     let x = 2.0*m;
     let y = 16.0*m*m*m*m;
     assert_eq!(x, P4::root(x*x*x*x));
-    # }
     ```
     */
     fn root(radicand: Radicand) -> Self::Output;
@@ -214,18 +203,13 @@ pub trait Pow<Base> {
     /**
     # Example
     ```
-    # extern crate typenum;
-    # extern crate dimensioned;
-
     use dimensioned::si::m;
     use dimensioned::Pow;
-    use typenum::consts::P3;
+    use dimensioned::P3;
 
-    # fn main() {
     let x = 2.0*m;
     let y = 8.0*m*m*m;
     assert_eq!(P3::pow(x), y);
-    # }
     ```
     */
     fn pow(base: Base) -> Self::Output;
@@ -292,11 +276,10 @@ Note: This macro requires that `Dim` and `Dimension` be imported.
 
 # Example
 ```rust
-extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 
-use typenum::Same;
+use dimensioned::Same;
 use dimensioned::{Dim, Dimension};
 use dimensioned::si::m;
 use std::ops::Mul;

--- a/src/dimensioned.rs
+++ b/src/dimensioned.rs
@@ -8,10 +8,9 @@ aid in generic programming and should not be implemented for anything outside th
 module. They are `Dimension`, `Dimensionless`, and `DimToString`.
 */
 
-use peano::{Same};
-use peano::{P2, P3};
-
-use peano::{Peano, ToInt};
+use typenum::Same;
+use typenum::consts::{P2, P3};
+use typenum::int::Integer;
 use std::marker::PhantomData;
 
 use std::ops::{Add, Sub, Mul, Div, Neg, BitAnd, BitOr, BitXor, FnOnce, Not, Rem, Shl, Shr};
@@ -134,7 +133,7 @@ pub trait Cbrt {
     Take a cube root.
     # Example
     ```
-    # extern crate peano;
+    # extern crate typenum;
     # extern crate dimensioned;
     use dimensioned::si::m;
     use dimensioned::Cbrt;
@@ -159,7 +158,7 @@ impl<D, V> Cbrt for Dim<D, V> where D: Dimension + Root<P3>, V: Float, <D as Roo
 **Root<Radicand>** is used for implementing general integer roots for types that don't
 `impl Float` and whose type signature changes when taking a root, such as `Dim<D, V>`.
 
-It uses Peano numbers to specify the degree.
+It uses typenum numbers to specify the degree.
 
 The syntax is a little bit weird and may be subject to change.
 */
@@ -170,12 +169,12 @@ pub trait Root<Radicand> {
     /**
     # Example
     ```
-    # extern crate peano;
+    # extern crate typenum;
     # extern crate dimensioned;
 
     use dimensioned::si::m;
     use dimensioned::Root;
-    use peano::P4;
+    use typenum::consts::P4;
 
     # fn main() {
     let x = 2.0*m;
@@ -186,10 +185,10 @@ pub trait Root<Radicand> {
     */
     fn root(radicand: Radicand) -> Self::Output;
 }
-impl<D, V, Degree> Root<Dim<D, V>> for Degree where D: Dimension + Root<Degree>, V: Float, Degree: Peano + ToInt, <D as Root<Degree>>::Output: Dimension {
+impl<D, V, Degree> Root<Dim<D, V>> for Degree where D: Dimension + Root<Degree>, V: Float, Degree: Integer, <D as Root<Degree>>::Output: Dimension {
     type Output = Dim<<D as Root<Degree>>::Output, V>;
     fn root(base: Dim<D, V>) -> Self::Output {
-        let x: V = NumCast::from(Degree::to_int()).expect("Attempted to take nth root of a Dim<D, V>, but could not convert from i32 to V to compute n.");
+        let x: V = NumCast::from(Degree::to_i32()).expect("Attempted to take nth root of a Dim<D, V>, but could not convert from i32 to V to compute n.");
         Dim::new( (base.0).powf(x.recip()) )
     }
 }
@@ -198,7 +197,7 @@ impl<D, V, Degree> Root<Dim<D, V>> for Degree where D: Dimension + Root<Degree>,
 **Pow<Base>** is used for implementing general integer powers for types that don't `impl
 Float` and whose type signature changes when multiplying, such as `Dim<D, V>`.
 
-It uses Peano numbers to specify the degree.
+It uses typenum numbers to specify the degree.
 
 The syntax is a little bit weird and may be subject to change.
 */
@@ -208,12 +207,12 @@ pub trait Pow<Base> {
     /**
     # Example
     ```
-    # extern crate peano;
+    # extern crate typenum;
     # extern crate dimensioned;
 
     use dimensioned::si::m;
     use dimensioned::Pow;
-    use peano::P3;
+    use typenum::consts::P3;
 
     # fn main() {
     let x = 2.0*m;
@@ -224,10 +223,10 @@ pub trait Pow<Base> {
     */
     fn pow(base: Base) -> Self::Output;
 }
-impl<D, V, Exp> Pow<Dim<D, V>> for Exp where D: Dimension + Pow<Exp>, V: Float, Exp: Peano + ToInt, <D as Pow<Exp>>::Output: Dimension {
+impl<D, V, Exp> Pow<Dim<D, V>> for Exp where D: Dimension + Pow<Exp>, V: Float, Exp: Integer, <D as Pow<Exp>>::Output: Dimension {
     type Output = Dim<<D as Pow<Exp>>::Output, V>;
     fn pow(base: Dim<D, V>) -> Self::Output {
-        Dim::new( (base.0).powi(Exp::to_int()) )
+        Dim::new( (base.0).powi(Exp::to_i32()) )
     }
 }
 
@@ -277,8 +276,8 @@ one of:
 * `Mul`: Multiplies `Self` by `Self`. The same as `Pow<P2>`.
 * `Div`: Divides `Self` by `Self`. The same as `Pow<Zero>`.
 * `Recip`: Gives the reciprocal of `Self`.
-* `Pow<N>`: Raises `Self` to the exponent `N` where `N` is a Peano number.
-* `Root<N>`: Takes the `N`th root of `Self` where `N` is a Peano number.
+* `Pow<N>`: Raises `Self` to the exponent `N` where `N` is a Typenum number.
+* `Root<N>`: Takes the `N`th root of `Self` where `N` is a Typenum number.
 * `Sqrt`: Takes the square root of `Self`. The same as `Root<P2>`.
 * `Cbrt`: Takes the cube root of `Self`. The same as `Root<P3>`.
 
@@ -286,11 +285,11 @@ Note: This macro requires that `Dim` and `Dimension` be imported.
 
 # Example
 ```rust
-extern crate peano;
+extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 
-use peano::Same;
+use typenum::Same;
 use dimensioned::{Dim, Dimension};
 use dimensioned::si::m;
 use std::ops::Mul;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ For in depth tutorials, check [here](http://paholg.com/project/dimensioned).
 extern crate typenum;
 extern crate num;
 
+pub use typenum::Same;
+pub use typenum::int::Integer;
+pub use typenum::consts::{N9, N8, N7, N6, N5, N4, N3, N2, N1, Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9};
 
 pub use dimensioned::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ For in depth tutorials, check [here](http://paholg.com/project/dimensioned).
 #![feature(type_macros)]
 
 
-extern crate peano;
+extern crate typenum;
 extern crate num;
 
 

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -110,7 +110,7 @@ Once associated constants hit, `std::num::One` will be used to determine the ini
 The `base` block is used to define the base units of this system. The line `P2,
 Centimeter, cm, cm;` creates the unit `Centimeter`, the corresponding constant `cm`, and
 will use the token "cm" to print `Centimeter`s. It also states that square roots will be
-allowed for `Centimeter`s; the `P2` is the typenum number for 2 and dictates the highest
+allowed for `Centimeter`s; the `P2` is the type number for 2 and dictates the highest
 root allowed. You will almost always want this to be `P1`. For `CGS`, though, some
 derived units are defined in terms of square roots of base units, so they are necessary
 to allow.
@@ -131,7 +131,6 @@ macro_rules! make_units_adv {
      } ) => (
         #[allow(unused_imports)]
         use typenum::consts::{Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9, N1, N2, N3, N4, N5, N6, N7, N8, N9};
-        use typenum::Same;
         use typenum::int::Integer;
         use $crate::{Dimension, Dimensionless, Dim, Pow, Root, Recip, DimToString};
         use ::std::ops::{Add, Neg, Sub, Mul, Div};

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -146,15 +146,6 @@ macro_rules! make_units_adv {
         // using $Type and $constant for these traits is confusing. It should really be $Type_Left and
         // $Type_Right or something, but as far as I can tell, that is not supported by Rust
         #[allow(non_camel_case_types)]
-        impl<$($Type),*, $($constant),*> Same<$System<$($constant),*>> for $System<$($Type),*>
-            where $($Type: Same<$constant>),*,
-                  $($constant: Integer),*,
-                  $(<$Type as Same<$constant>>::Output: Integer),*,
-                  $System<$(<$Type as Same<$constant>>::Output),*>: Dimension,
-        {
-            type Output = $System<$(<$Type as Same<$constant>>::Output),*>;
-        }
-        #[allow(non_camel_case_types)]
         impl<$($Type),*, $($constant),*> Mul<$System<$($constant),*>> for $System<$($Type),*>
             where $($Type: Integer + Add<$constant>),*,
         $($constant: Integer),*,

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -8,7 +8,6 @@ Note that it has some imports from the peano crate, so it must be included.
 
 # Example
 ```rust
-extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 
@@ -79,7 +78,6 @@ inside of its own module.
 Here we define the **CGS** unit system.
 
 ```rust
-extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 
@@ -130,8 +128,8 @@ macro_rules! make_units_adv {
          $($derived_constant:ident: $Derived:ident = $e:expr;)*
      } ) => (
         #[allow(unused_imports)]
-        use typenum::consts::{Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9, N1, N2, N3, N4, N5, N6, N7, N8, N9};
-        use typenum::int::Integer;
+        use $crate::{Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9, N1, N2, N3, N4, N5, N6, N7, N8, N9};
+        use $crate::Integer;
         use $crate::{Dimension, Dimensionless, Dim, Pow, Root, Recip, DimToString};
         use ::std::ops::{Add, Neg, Sub, Mul, Div};
         use ::std::marker::PhantomData;

--- a/tests/dim-ops.rs
+++ b/tests/dim-ops.rs
@@ -1,7 +1,7 @@
-extern crate peano;
+extern crate typenum;
 extern crate dimensioned as dim;
 
-use peano::{P2, P3, P6};
+use typenum::consts::{P2, P3, P6};
 use dim::si::{m};
 use dim::{Pow, Root, Sqrt, Cbrt};
 

--- a/tests/unit-making.rs
+++ b/tests/unit-making.rs
@@ -1,4 +1,4 @@
-extern crate peano;
+extern crate typenum;
 #[macro_use]
 extern crate dimensioned;
 


### PR DESCRIPTION
This still has the following error, but it's getting late:

```
note: conflicting implementation in crate `typenum`
src/make_units.rs:149:9: 156:10 error: conflicting implementations for trait `typenum::Same` [E0119]
src/make_units.rs:149         impl<$($Type),*, $($constant),*> Same<$System<$($constant),*>> for $System<$($Type),*>
src/make_units.rs:150             where $($Type: Integer + Same<$constant>),*,
src/make_units.rs:151                   $($constant: Integer),*,
src/make_units.rs:152                   $(<$Type as Same<$constant>>::Output: Integer),*,
src/make_units.rs:153                   $System<$(<$Type as Same<$constant>>::Output),*>: Dimension,
src/make_units.rs:154         {
                      ...
src/cgs.rs:10:1: 19:2 note: in this expansion of make_units_adv! (defined in src/make_units.rs)
src/make_units.rs:149:9: 156:10 help: run `rustc --explain E0119` to see a detailed explanation
```