### PR TITLE
Rename Dim<D, V> to Quantity<D, V>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 This project follows semantic versioning.
 
 ### Unpublished
+- `[changed]` Renamed `Dim<D, V>` to `Quantity<D, V>`.
 - `[added]` Unit conversion example.
-- `[changed]` Removed `Dimensioned` constraint for `D` in `Dim<D, V>`. This enables derived types to work properly. It is a temporary change only until the bug with Rust is fixed. See [issue #6](https://github.com/paholg/dimensioned/issues/6).
+- `[changed]` Removed `Dimensioned` constraint for `D` in `Quantity<D, V>`. This enables derived types to work properly. It is a temporary change only until the bug with Rust is fixed. See [issue #6](https://github.com/paholg/dimensioned/issues/6).
 - `[added]` Macro for constructing derived units. The derived block of `make_units!` also now works.
 
 ### 0.5.0 (2015-12-02)

--- a/examples/conversion.rs
+++ b/examples/conversion.rs
@@ -4,7 +4,7 @@
 extern crate dimensioned as dim;
 extern crate typenum;
 
-use dim::{Dim};
+use dim::{Quantity};
 use dim::cgs::{self, CGS, FromCGS};
 use typenum::int::Integer;
 
@@ -25,7 +25,7 @@ mod fps {
         }
     }
     pub trait FromFPS<Foot: Integer, Pound: Integer, Second: Integer, V> where Self: Sized {
-        fn from_fps(from: Dim<FPS<Foot, Pound, Second>, V>) -> Dim<Self, V>;
+        fn from_fps(from: Quantity<FPS<Foot, Pound, Second>, V>) -> Quantity<Self, V>;
     }
 }
 
@@ -33,8 +33,8 @@ use fps::{FPS};
 
 impl<Centimeter, Gram, Second, V> FromCGS<Centimeter, Gram, Second, V> for FPS<Centimeter, Gram, Second>
     where V: Mul<f64, Output=V>, Centimeter: Integer, Gram: Integer, Second: Integer, {
-    fn from_cgs(from: Dim<CGS<Centimeter, Gram, Second>, V>) -> Dim<Self, V> {
-        Dim::new( from.0 * 0.0328084f64.sqrt().powi(Centimeter::to_i32()) * 0.00220462f64.sqrt().powi(Gram::to_i32()) )
+    fn from_cgs(from: Quantity<CGS<Centimeter, Gram, Second>, V>) -> Quantity<Self, V> {
+        Quantity::new( from.0 * 0.0328084f64.sqrt().powi(Centimeter::to_i32()) * 0.00220462f64.sqrt().powi(Gram::to_i32()) )
     }
 }
 

--- a/examples/simple_conversion.rs
+++ b/examples/simple_conversion.rs
@@ -2,7 +2,7 @@
 extern crate dimensioned as dim;
 extern crate typenum;
 
-use dim::Dim;
+use dim::Quantity;
 use typenum::Integer;
 use std::ops::Mul;
 
@@ -18,7 +18,7 @@ mod ms {
     }
 
     pub trait FromMS<Meter: Integer, Second: Integer, V> where Self: Sized {
-        fn from_ms(from: Dim<MS<Meter, Second>, V>) -> Dim<Self, V>;
+        fn from_ms(from: Quantity<MS<Meter, Second>, V>) -> Quantity<Self, V>;
     }
 }
 
@@ -35,19 +35,19 @@ mod fs {
     }
 
     pub trait FromFS<Foot: Integer, Second: Integer, V> where Self: Sized {
-        fn from_fs(from: Dim<FS<Foot, Second>, V>) -> Dim<Self, V>;
+        fn from_fs(from: Quantity<FS<Foot, Second>, V>) -> Quantity<Self, V>;
     }
 }
 
 impl<Meter: Integer, Second: Integer, V: Mul<f64, Output = V>> ms::FromMS<Meter, Second, V> for fs::FS<Meter, Second> {
-    fn from_ms(from: Dim<ms::MS<Meter, Second>, V>) -> Dim<Self, V> {
-        Dim::new(from.0 * 3.281)
+    fn from_ms(from: Quantity<ms::MS<Meter, Second>, V>) -> Quantity<Self, V> {
+        Quantity::new(from.0 * 3.281)
     }
 }
 
 impl<Foot: Integer, Second: Integer, V: Mul<f64, Output = V>> fs::FromFS<Foot, Second, V> for ms::MS<Foot, Second> {
-    fn from_fs(from: Dim<fs::FS<Foot, Second>, V>) -> Dim<Self, V> {
-        Dim::new(from.0 * 0.305)
+    fn from_fs(from: Quantity<fs::FS<Foot, Second>, V>) -> Quantity<Self, V> {
+        Quantity::new(from.0 * 0.305)
     }
 }
 

--- a/examples/vector3a.rs
+++ b/examples/vector3a.rs
@@ -7,7 +7,7 @@ use vector3a::Vector3;
 use typenum::Same;
 use std::ops::{Mul};
 use dimensioned::si::{one, m, kg, s};
-use dimensioned::{Dim, Dimension};
+use dimensioned::{Quantity, Dimension};
 
 dim_impl_unary!(Norm, norm, Same, Vector3 => f64);
 dim_impl_unary!(Norm2, norm2, Mul, Vector3 => f64);

--- a/examples/vector3c.rs
+++ b/examples/vector3c.rs
@@ -46,7 +46,7 @@ fn main() {
 //     use std::fmt::{self, Display};
 //     use std::marker::PhantomData;
 
-//     use dimensioned::{Dim, Dimension, MulDim, Sqrt, DimToString};
+//     use dimensioned::{Quantity, Dimension, MulQuantity, Sqrt, QuantityToString};
 
 //     #[derive(Copy, Clone)]
 //     pub struct Vector3<D: Dimension> {
@@ -67,8 +67,8 @@ fn main() {
 //         type Output;
 //         fn cross(self, rhs: RHS) -> Self::Output;
 //     }
-//     impl<Dl, Dr> Cross<Vector3<Dr>> for Vector3<Dl> where Dl: Dimension + MulDim<Dr>, Dr: Dimension, <Dl as MulDim<Dr>>::Output: Dimension {
-//         type Output = Vector3<<Dl as MulDim<Dr>>::Output>;
+//     impl<Dl, Dr> Cross<Vector3<Dr>> for Vector3<Dl> where Dl: Dimension + MulQuantity<Dr>, Dr: Dimension, <Dl as MulQuantity<Dr>>::Output: Dimension {
+//         type Output = Vector3<<Dl as MulQuantity<Dr>>::Output>;
 //         #[inline]
 //         fn cross(self, rhs: Vector3<Dr>) -> Self::Output {
 //             Vector3::new(self.y*rhs.z - self.z*rhs.y,
@@ -81,11 +81,11 @@ fn main() {
 //         type Output;
 //         fn dot(self, rhs: RHS) -> Self::Output;
 //     }
-//     impl<Dl, Dr> Dot<Vector3<Dr>> for Vector3<Dl> where Dl: Dimension + MulDim<Dr>, Dr: Dimension, <Dl as MulDim<Dr>>::Output: Dimension {
-//         type Output = Dim<<Dl as MulDim<Dr>>::Output, f64>;
+//     impl<Dl, Dr> Dot<Vector3<Dr>> for Vector3<Dl> where Dl: Dimension + MulQuantity<Dr>, Dr: Dimension, <Dl as MulQuantity<Dr>>::Output: Dimension {
+//         type Output = Quantity<<Dl as MulQuantity<Dr>>::Output, f64>;
 //         #[inline]
 //         fn dot(self, rhs: Vector3<Dr>) -> Self::Output {
-//             Dim::new( self.x*rhs.x + self.y*rhs.y + self.z*rhs.z )
+//             Quantity::new( self.x*rhs.x + self.y*rhs.y + self.z*rhs.z )
 //         }
 //     }
 
@@ -93,8 +93,8 @@ fn main() {
 //         type Output;
 //         fn norm2(self) -> <Self as Norm2>::Output;
 //     }
-//     impl<D> Norm2 for Vector3<D> where Vector3<D>: Copy, D: Dimension + MulDim, <D as MulDim>::Output: Dimension {
-//         type Output = Dim<<D as MulDim>::Output, f64>;
+//     impl<D> Norm2 for Vector3<D> where Vector3<D>: Copy, D: Dimension + MulQuantity, <D as MulQuantity>::Output: Dimension {
+//         type Output = Quantity<<D as MulQuantity>::Output, f64>;
 //         #[inline]
 //         fn norm2(self) -> <Self as Norm2>::Output {
 //             self.dot(self)
@@ -105,8 +105,8 @@ fn main() {
 //         type Output;
 //         fn norm(self) -> <Self as Norm>::Output;
 //     }
-//     impl<D> Norm for Vector3<D> where D: Dimension + MulDim + Copy, <D as MulDim>::Output: Dimension, Dim<<D as MulDim>::Output, f64>: Sqrt {
-//         type Output = <Dim<<D as MulDim>::Output, f64> as Sqrt>::Output;
+//     impl<D> Norm for Vector3<D> where D: Dimension + MulQuantity + Copy, <D as MulQuantity>::Output: Dimension, Quantity<<D as MulQuantity>::Output, f64>: Sqrt {
+//         type Output = <Quantity<<D as MulQuantity>::Output, f64> as Sqrt>::Output;
 //         #[inline]
 //         fn norm(self) -> <Self as Norm>::Output {
 //             self.norm2().sqrt()
@@ -159,7 +159,7 @@ fn main() {
 //         }
 //     }
 
-//     impl<D: Dimension + DimToString> Display for Vector3<D> {
+//     impl<D: Dimension + QuantityToString> Display for Vector3<D> {
 //         fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
 //             write!(f, "({}, {}, {}) {}", self.x, self.y, self.z, D::to_string())
 //         }

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -98,7 +98,7 @@ mod cgs {
 
 The line `CGS, Unitless, one, f64, 1.0;` names the unit system `CGS`, names its type for
 unitless data `Unitless` and creates the corresponding constant `one`. It also states
-that all constants will be of type `Dim<D, f64>` and will be initialized to a value of
+that all constants will be of type `Quantity<D, f64>` and will be initialized to a value of
 `1.0`.
 
 Once associated constants hit, `std::num::One` will be used to determine the initalize value.
@@ -127,7 +127,7 @@ macro_rules! make_units_adv {
         #[allow(unused_imports)]
         use $crate::{Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9, N1, N2, N3, N4, N5, N6, N7, N8, N9};
         use $crate::Integer;
-        use $crate::{Dimension, Dimensionless, Dim, Pow, Root, Recip, DimToString};
+        use $crate::{Dimension, Dimensionless, Quantity, Pow, Root, Recip, QuantityToString};
         use ::std::ops::{Add, Neg, Sub, Mul, Div};
         use ::std::marker::PhantomData;
 
@@ -197,7 +197,7 @@ macro_rules! make_units_adv {
         }
 
 
-        impl<$($Type),*> DimToString for $System<$($Type),*>
+        impl<$($Type),*> QuantityToString for $System<$($Type),*>
             where $($Type: Integer),* {
             fn to_string() -> String {
                 // fixme: add #[allow(unused_variables)] lints for these. Not working
@@ -213,15 +213,15 @@ macro_rules! make_units_adv {
         pub type $Unitless = $System;
         impl Dimensionless for $Unitless {}
         #[allow(non_upper_case_globals, dead_code)]
-        pub const $one: Dim<$Unitless, $OneType> = Dim($val, PhantomData);
+        pub const $one: Quantity<$Unitless, $OneType> = Quantity($val, PhantomData);
 
         __make_base_types!($System, $($Type, $Root),+ |);
 
-        $(#[allow(non_upper_case_globals)] pub const $constant: Dim<$Type, $OneType> = Dim($val, PhantomData));*;
+        $(#[allow(non_upper_case_globals)] pub const $constant: Quantity<$Type, $OneType> = Quantity($val, PhantomData));*;
 
         $(pub type $Derived = unit!($($derived_rhs)+);
           #[allow(non_upper_case_globals)]
-          pub const $derived_constant: Dim<$Derived, $OneType> = Dim($val, PhantomData);
+          pub const $derived_constant: Quantity<$Derived, $OneType> = Quantity($val, PhantomData);
         )*
         );
 }
@@ -274,11 +274,11 @@ macro_rules! __make_base_types {
 /// #[macro_use]
 /// extern crate dimensioned as dim;
 /// use std::ops::Div;
-/// use dim::{Dim};
+/// use dim::{Quantity};
 /// use dim::si::*;
 /// type MPS = unit!(Meter / Second);
 ///
-/// fn speed(dist: Dim<Meter, f64>, time: Dim<Second, f64>) -> Dim<MPS, f64> {
+/// fn speed(dist: Quantity<Meter, f64>, time: Quantity<Second, f64>) -> Quantity<MPS, f64> {
 ///     dist / time
 /// }
 ///

--- a/src/unit_systems/cgs.rs
+++ b/src/unit_systems/cgs.rs
@@ -20,14 +20,14 @@ make_units_adv! {
 }
 
 pub trait FromCGS<Centimeter: Integer, Gram: Integer, Second: Integer, V> where Self: Sized {
-    fn from_cgs(from: Dim<CGS<Centimeter, Gram, Second>, V>) -> Dim<Self, V>;
+    fn from_cgs(from: Quantity<CGS<Centimeter, Gram, Second>, V>) -> Quantity<Self, V>;
 }
 
 use mks::{MKS, FromMKS};
 impl<Meter, Kilogram, Second, V> FromMKS<Meter, Kilogram, Second, V> for CGS<Meter, Kilogram, Second>
     where V: Mul<f64, Output=V>, Meter: Integer, Kilogram: Integer, Second: Integer, {
-    fn from_mks(from: Dim<MKS<Meter, Kilogram, Second>, V>) -> Dim<Self, V> {
-        Dim::new( from.0 * 100f64.sqrt().powi(Meter::to_i32()) * 1000f64.sqrt().powi(Kilogram::to_i32()) )
+    fn from_mks(from: Quantity<MKS<Meter, Kilogram, Second>, V>) -> Quantity<Self, V> {
+        Quantity::new( from.0 * 100f64.sqrt().powi(Meter::to_i32()) * 1000f64.sqrt().powi(Kilogram::to_i32()) )
     }
 }
 

--- a/src/unit_systems/mks.rs
+++ b/src/unit_systems/mks.rs
@@ -19,13 +19,13 @@ make_units_adv! {
 }
 
 pub trait FromMKS<Meter: Integer, Kilogram: Integer, Second: Integer, V> where Self: Sized {
-    fn from_mks(from: Dim<MKS<Meter, Kilogram, Second>, V>) -> Dim<Self, V>;
+    fn from_mks(from: Quantity<MKS<Meter, Kilogram, Second>, V>) -> Quantity<Self, V>;
 }
 
 use cgs::{CGS, FromCGS};
 impl<Centimeter, Gram, Second, V> FromCGS<Centimeter, Gram, Second, V> for MKS<Centimeter, Gram, Second>
     where V: Mul<f64, Output=V>, Centimeter: Integer, Gram: Integer, Second: Integer, {
-    fn from_cgs(from: Dim<CGS<Centimeter, Gram, Second>, V>) -> Dim<Self, V> {
-        Dim::new( from.0 * 0.01f64.sqrt().powi(Centimeter::to_i32()) * 0.001f64.sqrt().powi(Gram::to_i32()) )
+    fn from_cgs(from: Quantity<CGS<Centimeter, Gram, Second>, V>) -> Quantity<Self, V> {
+        Quantity::new( from.0 * 0.01f64.sqrt().powi(Centimeter::to_i32()) * 0.001f64.sqrt().powi(Gram::to_i32()) )
     }
 }

--- a/src/unit_systems/si.rs
+++ b/src/unit_systems/si.rs
@@ -28,7 +28,7 @@ make_units! {
 //     let mass = 3.0 * kg;
 //     let dist = 2.0 * m;
 //     let time = 2.0 * s;
-//     let f: Dim<Newton, f64> = Dim::new(1.5);
+//     let f: Quantity<Newton, f64> = Quantity::new(1.5);
 
 //     assert_eq!(f, mass * dist / time / time);
 // }

--- a/tests/derived.rs
+++ b/tests/derived.rs
@@ -2,21 +2,21 @@
 #[macro_use]
 extern crate dimensioned as dim;
 
-use dim::Dim;
+use dim::Quantity;
 use dim::si::{Meter, Second};
 use std::ops::Div;
 use std::marker::PhantomData;
 
 type MPS = unit!(Meter / Second);
 
-fn speed(dist: Dim<Meter, f64>, time: Dim<Second, f64>) -> Dim<MPS, f64> {
+fn speed(dist: Quantity<Meter, f64>, time: Quantity<Second, f64>) -> Quantity<MPS, f64> {
     dist / time
 }
 
 #[test]
 fn derived() {
-    let d: Dim<Meter, f64> = Dim::new(3.0);
-    let t: Dim<Second, f64> = Dim::new(2.0);
+    let d: Quantity<Meter, f64> = Quantity::new(3.0);
+    let t: Quantity<Second, f64> = Quantity::new(2.0);
 
     let v = speed(d, t);
 

--- a/todo.org
+++ b/todo.org
@@ -8,7 +8,7 @@
 
 # Questions
 - make_units_adv! :: Allow custom print function?
-- Dim :: Decide on other traits to implement.
+- Quantity :: Decide on other traits to implement.
 - Macros :: Investigate more macros for implementing functions.
 
 # Future


### PR DESCRIPTION
The struct represents a quantity[1] having a quantity dimension[2] and a
base quantity[3]. Resolves #11.

As mentioned in #11 please close this if you believe it's too much of a change.

[1] http://jcgm.bipm.org/vim/en/1.1.html
[2] http://jcgm.bipm.org/vim/en/1.7.html
[3] http://jcgm.bipm.org/vim/en/1.4.html