### PR TITLE
No std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   - |
     travis-cargo build &&
     travis-cargo test &&
+    travis-cargo test -- --no-default-features &&
     travis-cargo doc
 
 after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@
   name = "dimensioned"
 
 [features]
-  no_std = []
+  default = ["std"]
+  std = []
 
 [dependencies]
   typenum = "1.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@
 [lib]
   name = "dimensioned"
 
+[features]
+  no_std = []
+
 [dependencies]
-  num = "0.1.34"
   typenum = "1.3.2"

--- a/examples/vector3b.rs
+++ b/examples/vector3b.rs
@@ -1,22 +1,8 @@
 extern crate dimensioned as dim;
-extern crate num;
 
-use vector3b::{Vector3, Norm2, Cross};
+use vector3b::{Vector3, Cross, Norm};
 
-use dim::Sqrt;
 use dim::si::{one, m, kg, s};
-
-pub trait Norm {
-    type Output;
-    fn norm(self) -> Self::Output;
-}
-
-impl<N> Norm for Vector3<N> where Vector3<N>: Norm2, <Vector3<N> as Norm2>::Output: Sqrt {
-    type Output = <<Vector3<N> as Norm2>::Output as Sqrt>::Output;
-    #[inline]
-    fn norm(self) -> Self::Output { self.norm2().sqrt() }
-}
-
 
 fn main() {
     let xhat = Vector3::new(one, 0.0*one, 0.0*one);
@@ -54,9 +40,9 @@ fn main() {
 }
 
 mod vector3b {
-    use num::Float;
     use std::ops::{Add, Sub, Mul, Div};
     use std::fmt::{self, Display};
+    use dim::Sqrt;
 
     #[derive(Copy, Clone)]
     pub struct Vector3<N> {
@@ -97,8 +83,8 @@ mod vector3b {
         fn norm(self) -> Self::Output;
     }
 
-    impl<N> Norm for Vector3<N> where Vector3<N>: Norm2, <Vector3<N> as Norm2>::Output: Float {
-        type Output = <Vector3<N> as Norm2>::Output;
+    impl<N> Norm for Vector3<N> where Vector3<N>: Norm2, <Vector3<N> as Norm2>::Output: Sqrt {
+        type Output = <<Vector3<N> as Norm2>::Output as Sqrt>::Output;
         #[inline]
         fn norm(self) -> Self::Output { self.norm2().sqrt() }
     }

--- a/src/dim.rs
+++ b/src/dim.rs
@@ -13,7 +13,6 @@ use {Same, Integer, P2, P3};
 use std::marker::PhantomData;
 
 use std::ops::{Add, Sub, Mul, Div, Neg, BitAnd, BitOr, BitXor, FnOnce, Not, Rem, Shl, Shr};
-use num::traits::{Float, FromPrimitive, ToPrimitive, NumCast};
 use std::cmp::{Eq, PartialEq, Ord, PartialOrd, Ordering};
 use std::fmt;
 
@@ -80,14 +79,12 @@ impl<D, V> Dim<D, V> {
     # Example
     ```
     # extern crate dimensioned;
-    # extern crate num;
 
-    use num::traits::Float;
     use dimensioned::si::m;
 
     # fn main() {
-    let x = 3.5*m;
-    assert_eq!(3.0*m, x.map(Float::trunc) );
+    let x = 4.0*m;
+    assert_eq!(2.0*m, x.map(|x| x.sqrt()) );
     # }
     ```
      */
@@ -105,7 +102,7 @@ pub trait NotDim {}
 impl NotDim for .. {}
 impl<D, V> !NotDim for Dim<D, V> {}
 
-/// **Sqrt** is used for implementing a `sqrt()` member for types that don't `impl Float`.
+/// **Sqrt** provides a `sqrt` member function.
 pub trait Sqrt {
     #[allow(missing_docs)]
     type Output;
@@ -124,13 +121,26 @@ pub trait Sqrt {
     fn sqrt(self) -> Self::Output;
 }
 
-impl<D, V> Sqrt for Dim<D, V> where D: Root<P2>, V: Float, <D as Root<P2>>::Output: Dimension {
-    type Output = Dim<<D as Root<P2>>::Output, V>;
+impl<D, V> Sqrt for Dim<D, V> where D: Root<P2>, V: Sqrt, <D as Root<P2>>::Output: Dimension {
+    type Output = Dim<<D as Root<P2>>::Output, <V as Sqrt>::Output>;
     #[inline]
     fn sqrt(self) -> Self::Output { Dim( (self.0).sqrt(), PhantomData) }
 }
 
-/// **Cbrt** is used for implementing a `cbrt()` member for types that don't `impl Float`.
+macro_rules! impl_sqrt {
+    ($t: ty) => (
+        impl<D> Sqrt for Dim<D, $t> where D: Root<P2>, <D as Root<P2>>::Output: Dimension {
+            type Output = Dim<<D as Root<P2>>::Output, $t>;
+            #[inline]
+            fn sqrt(self) -> Self::Output { Dim( (self.0).sqrt(), PhantomData) }
+        }
+    );
+}
+
+impl_sqrt!(f32);
+impl_sqrt!(f64);
+
+/// **Cbrt** provides a `cbrt` member function.
 pub trait Cbrt {
     #[allow(missing_docs)]
     type Output;
@@ -149,11 +159,24 @@ pub trait Cbrt {
     fn cbrt(self) -> Self::Output;
 }
 
-impl<D, V> Cbrt for Dim<D, V> where D: Root<P3>, V: Float, <D as Root<P3>>::Output: Dimension {
-    type Output = Dim<<D as Root<P3>>::Output, V>;
+impl<D, V> Cbrt for Dim<D, V> where D: Root<P3>, V: Cbrt, <D as Root<P3>>::Output: Dimension {
+    type Output = Dim<<D as Root<P3>>::Output, <V as Cbrt>::Output>;
     #[inline]
     fn cbrt(self) -> Self::Output { Dim( (self.0).cbrt(), PhantomData) }
 }
+
+macro_rules! impl_cbrt {
+    ($t: ty) => (
+        impl<D> Cbrt for Dim<D, $t> where D: Root<P3>, <D as Root<P3>>::Output: Dimension {
+            type Output = Dim<<D as Root<P3>>::Output, $t>;
+            #[inline]
+            fn cbrt(self) -> Self::Output { Dim( (self.0).cbrt(), PhantomData) }
+        }
+    );
+}
+
+impl_cbrt!(f32);
+impl_cbrt!(f64);
 
 /**
 **Root<Radicand>** is used for implementing general integer roots for types that don't
@@ -181,45 +204,72 @@ pub trait Root<Radicand> {
     */
     fn root(radicand: Radicand) -> Self::Output;
 }
-impl<D, V, Degree> Root<Dim<D, V>> for Degree where D: Root<Degree>, V: Float, Degree: Integer, <D as Root<Degree>>::Output: Dimension {
-    type Output = Dim<<D as Root<Degree>>::Output, V>;
-    fn root(base: Dim<D, V>) -> Self::Output {
-        let x: V = NumCast::from(Degree::to_i32()).expect("Attempted to take nth root of a Dim<D, V>, but could not convert from i32 to V to compute n.");
-        Dim::new( (base.0).powf(x.recip()) )
+
+impl<D, V, Index> Root<Dim<D, V>> for Index where D: Root<Index>, Index: Integer + Root<V> {
+    type Output = Dim<<D as Root<Index>>::Output, <Index as Root<V>>::Output>;
+    fn root(radicand: Dim<D, V>) -> Self::Output {
+        Dim::new( Index::root(radicand.0) )
     }
 }
 
-/**
-**Pow<Base>** is used for implementing general integer powers for types that don't `impl
-Float` and whose type signature changes when multiplying, such as `Dim<D, V>`.
+macro_rules! impl_root {
+    ($t: ty) => (
+        impl<Index: Integer> Root<$t> for Index {
+            type Output = $t;
+            fn root(radicand: $t) -> Self::Output {
+                radicand.powf((Index::to_i32() as $t).recip())
+            }
+        }
+    );
+}
 
-It uses type numbers to specify the degree.
+impl_root!(f32);
+impl_root!(f64);
 
-The syntax is a little bit weird and may be subject to change.
-*/
+/// **Pow<Base>** is used for implementing general integer powers for types that don't `impl
+/// Float` and whose type signature changes when multiplying, such as `Dim<D, V>`.
+///
+/// It uses type numbers to specify the degree.
+///
+/// The syntax is a little bit weird and may be subject to change.
 pub trait Pow<Base> {
     #[allow(missing_docs)]
     type Output;
-    /**
-    # Example
-    ```
-    use dimensioned::si::m;
-    use dimensioned::Pow;
-    use dimensioned::P3;
-
-    let x = 2.0*m;
-    let y = 8.0*m*m*m;
-    assert_eq!(P3::pow(x), y);
-    ```
-    */
+    /// #[allow(missing_docs)]
+    /// type Output;
+    /// # Example
+    /// ```
+    /// use dimensioned::si::m;
+    /// use dimensioned::Pow;
+    /// use dimensioned::P3;
+    ///
+    /// let x = 2.0*m;
+    /// let y = 8.0*m*m*m;
+    /// assert_eq!(P3::pow(x), y);
+    /// ```
     fn pow(base: Base) -> Self::Output;
 }
-impl<D, V, Exp> Pow<Dim<D, V>> for Exp where D: Pow<Exp>, V: Float, Exp: Integer, <D as Pow<Exp>>::Output: Dimension {
-    type Output = Dim<<D as Pow<Exp>>::Output, V>;
+
+impl<D, V, Exp> Pow<Dim<D, V>> for Exp where D: Pow<Exp>, Exp: Integer + Pow<V> {
+    type Output = Dim<<D as Pow<Exp>>::Output, <Exp as Pow<V>>::Output>;
     fn pow(base: Dim<D, V>) -> Self::Output {
-        Dim::new( (base.0).powi(Exp::to_i32()) )
+        Dim::new( Exp::pow(base.0) )
     }
 }
+
+macro_rules! impl_pow {
+    ($t: ty) => (
+        impl<Exp: Integer> Pow<$t> for Exp {
+            type Output = $t;
+            fn pow(base: $t) -> Self::Output {
+                base.powi(Exp::to_i32())
+            }
+        }
+    );
+}
+
+impl_pow!(f32);
+impl_pow!(f64);
 
 /// **Recip** is used for implementing a `recip()` member for types that don't `impl Float`.
 pub trait Recip {
@@ -238,12 +288,27 @@ pub trait Recip {
      */
     fn recip(self) -> Self::Output;
 }
-impl<D, V> Recip for Dim<D, V> where D: Recip, V: Float, <D as Recip>::Output: Dimension {
-    type Output = Dim<<D as Recip>::Output, V>;
+impl<D, V> Recip for Dim<D, V> where D: Recip, V: Recip, <D as Recip>::Output: Dimension {
+    type Output = Dim<<D as Recip>::Output, <V as Recip>::Output>;
     fn recip(self) -> Self::Output {
         Dim::new( (self.0).recip() )
     }
 }
+
+macro_rules! impl_recip {
+    ($t: ty) => (
+        impl Recip for $t {
+            type Output = $t;
+            fn recip(self) -> Self::Output {
+                self.recip()
+            }
+        }
+    );
+}
+
+impl_recip!(f32);
+impl_recip!(f64);
+
 
 // /**
 // **Convert** provides a useful trait for allowing unit conversions. The trait `std::convert::From` can't be used because it doesn't have an associated type.
@@ -538,6 +603,7 @@ macro_rules! dim_lhs_mult {
         }
         );
 }
+
 dim_lhs_mult!(f32);
 dim_lhs_mult!(f64);
 dim_lhs_mult!(i8);
@@ -644,160 +710,19 @@ dim_binary!(Sub, Same, sub);
 //     }
 // }
 
-//------------------------------------------------------------------------------
-// Casting
-macro_rules! cast_from {
-    ($fun:ident, $prim:ident) => (
-        #[inline]
-        fn $fun(n: $prim) -> Option<Self> {
-            match FromPrimitive::$fun(n) {
-                Some(v) => Some( Dim(v, PhantomData) ),
-                None => None
-            }
-        }
-        );
-}
+// {
 
-impl<D, V> FromPrimitive for Dim<D, V> where V: FromPrimitive {
-    cast_from!(from_i64, i64);
-    cast_from!(from_u64, u64);
-    cast_from!(from_isize, isize);
-    cast_from!(from_i8, i8);
-    cast_from!(from_i16, i16);
-    cast_from!(from_i32, i32);
-    cast_from!(from_usize, usize);
-    cast_from!(from_u8, u8);
-    cast_from!(from_u32, u32);
-    cast_from!(from_f32, f32);
-    cast_from!(from_f64, f64);
-}
+//     trait Sqr {
+//         fn sqr(self) -> Self;
+//     }
 
-macro_rules! cast_to {
-    ($fun:ident, $prim:ident) => (
-        #[inline]
-        fn $fun(&self) -> Option<$prim> {
-            (self.0).$fun()
-        }
-        );
-}
-
-impl<D, V> ToPrimitive for Dim<D, V> where V: ToPrimitive {
-    cast_to!(to_i64, i64);
-    cast_to!(to_u64, u64);
-    cast_to!(to_isize, isize);
-    cast_to!(to_i8, i8);
-    cast_to!(to_i16, i16);
-    cast_to!(to_i32, i32);
-    cast_to!(to_usize, usize);
-    cast_to!(to_u8, u8);
-    cast_to!(to_u16, u16);
-    cast_to!(to_u32, u32);
-    cast_to!(to_f32, f32);
-    cast_to!(to_f64, f64);
-}
-
-impl<D, V> NumCast for Dim<D, V> where V: NumCast {
-    #[inline]
-    fn from<N>(n: N) -> Option<Self> where N: ToPrimitive {
-        match NumCast::from(n) {
-            Some(v) => Some(Dim(v, PhantomData)),
-            None => None
-        }
-    }
-}
-
-//------------------------------------------------------------------------------
-// impl<D, V> ::std::num::Zero for Dim<D, V> where V: ::std::num::Zero {
-//     fn zero() -> Self {
-//         Dim::new(V::zero())
+//     macro_rules! impl_sqr {
+//         ($t:ty) => (
+//             impl Sqr for $t {
+//                 fn sqr(self) -> Self {
+//                     self * self
+//                 }
+//             }
+//         );
 //     }
 // }
-
-//------------------------------------------------------------------------------
-// DIMENSIONLESS THINGS HERE
-//------------------------------------------------------------------------------
-// impl<D, V> ::std::num::One for Dim<D, V> where D: Dimensionless + Mul<D>, V: ::std::num::One + Mul {
-//     fn one() -> Self {
-//         Dim::new(V::one())
-//     }
-// }
-
-//------------------------------------------------------------------------------
-// Num
-// impl<D, V> Num for Dim<D, V>
-//     where D: Dimensionless + Same<D>, V: Float, <D as Same<D>>::Output: Dimensionless {
-//         type FromStrRadixErr = Dim<D, <V as Num>::FromStrRadixErr>;
-//         fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
-//             Dim( <V as Num>::from_str_radix(str, radix));
-//         }
-//     }
-//------------------------------------------------------------------------------
-// Float
-// macro_rules! dim_unary_float {
-//     ($fun:ident, $returns:ty) => (
-//         fn $fun(self) -> $returns { Dim( (self.0).$fun(), PhantomData) }
-//         )
-// }
-
-// impl<D, V> Float for Dim<D, V>
-//     where D: Dimensionless + Same<D>, V: Float, <D as Same<D>>::Output: Dimensionless {
-//         // fn nan(self) -> Dim<D, V> {Dim ( (self.0).nan() )}
-//         dim_unary_float!(nan, Self);
-//         dim_unary_float!(infinity, Self);
-//         dim_unary_float!(neg_infinity, Self);
-//         dim_unary_float!(neg_zero, Self);
-//         dim_unary_float!(min_value, Self);
-//         //dim_unary_float!(min_positive_value, Self);
-//         dim_unary_float!(max_value, Self);
-//         dim_unary_float!(is_nan, bool);
-//         dim_unary_float!(is_infinite, bool);
-//         dim_unary_float!(is_finite, bool);
-//         dim_unary_float!(is_normal, bool);
-//         // dim_unary_float!(classify, FpCategory);
-//         dim_unary_float!(floor, Self);
-//         dim_unary_float!(ceil, Self);
-//         dim_unary_float!(round, Self);
-//         dim_unary_float!(trunc, Self);
-//         dim_unary_float!(fract, Self);
-//         dim_unary_float!(abs, Self);
-//         dim_unary_float!(signum, Self);
-//         dim_unary_float!(is_sign_positive, bool);
-//         dim_unary_float!(is_sign_negative, bool);
-//         // dim_unary_float!(mul_add, bool); BINARY
-
-//         dim_unary_float!(recip, Self);
-//         // powi
-//         // powf
-//         dim_unary_float!(sqrt, Self);
-//         dim_unary_float!(exp, Self);
-//         dim_unary_float!(exp2, Self);
-//         dim_unary_float!(ln, Self);
-//         dim_unary_float!(log, Self);
-//         dim_unary_float!(log2, Self);
-//         dim_unary_float!(log10, Self);
-//         dim_unary_float!(max, Self);
-//         dim_unary_float!(min, Self);
-//         // abs_sub
-//         dim_unary_float!(cbrt, Self);
-//         dim_unary_float!(hypot, Self);
-//         dim_unary_float!(sin, Self);
-//         dim_unary_float!(cos, Self);
-//         dim_unary_float!(tan, Self);
-//         dim_unary_float!(asin, Self);
-//         dim_unary_float!(acos, Self);
-//         dim_unary_float!(atan, Self);
-//         dim_unary_float!(atan2, Self);
-//         dim_unary_float!(sin_cos, (Self, Self));
-//         dim_unary_float!(exp_m1, Self);
-//         dim_unary_float!(ln_1p, Self);
-//         dim_unary_float!(sinh, Self);
-//         dim_unary_float!(cosh, Self);
-//         dim_unary_float!(tanh, Self);
-//         dim_unary_float!(asinh, Self);
-//         dim_unary_float!(acosh, Self);
-//         dim_unary_float!(atanh, Self);
-//         dim_unary_float!(integer_decode, (u64, i16, i8));
-
-//     }
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,34 @@
-/*!
-# dimensioned
-
-**dimensioned** is a library for compile time type checking for arbitrary unit systems.
-
-For in depth tutorials, check [here](http://paholg.com/project/dimensioned).
- */
+//! # dimensioned
+//!
+//! dimensioned** is a library for compile time type checking for arbitrary unit systems.
+//!
+//! For in depth tutorials, check [here](http://paholg.com/project/dimensioned).
+//!
 #![doc(html_logo_url = "http://paholg.com/dimensioned/imgs/favicon.png",
        html_favicon_url = "http://paholg.com/dimensioned/imgs/favicon.png",
        html_root_url = "http://paholg.com/dimensioned")]
 #![warn(missing_docs)]
 
 #![feature(optin_builtin_traits, const_fn)]
-#![feature(type_macros)]
+#![cfg_attr(not(feature="std"), feature(core_float, core_intrinsics))]
 
+#![cfg_attr(not(feature="std"), no_std)]
+
+/// Re-exports from std or core, which allow the `make_units` macro to work properly with or
+/// without the std library.  These are not guaranteed to stay here, and you should import from
+/// `core` or `std` directly, not from here.
+#[cfg(feature = "std")]
+pub mod reexported {
+    pub use std::*;
+}
+
+/// Re-exports from std or core, which allow the `make_units` macro to work properly with or
+/// without the std library.  These are not guaranteed to stay here, and you should import from
+/// `core` or `std` directly, not from here.
+#[cfg(not(feature="std"))]
+pub mod reexported {
+    pub use core::*;
+}
 
 pub extern crate typenum;
 
@@ -24,8 +40,8 @@ pub mod unit_systems;
 
 pub use typenum::Same;
 pub use typenum::int::Integer;
-pub use typenum::consts::{N9, N8, N7, N6, N5, N4, N3, N2, N1, Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9};
+pub use typenum::consts::{N9, N8, N7, N6, N5, N4, N3, N2, N1, Z0, P1, P2, P3, P4, P5, P6, P7, P8,
+                          P9};
 
 pub use dim::*;
 pub use unit_systems::{si, cgs, mks};
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,7 @@ For in depth tutorials, check [here](http://paholg.com/project/dimensioned).
 #![feature(type_macros)]
 
 
-extern crate typenum;
-extern crate num;
+pub extern crate typenum;
 
 #[macro_use]
 pub mod dim;

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -127,9 +127,10 @@ macro_rules! make_units_adv {
         #[allow(unused_imports)]
         use $crate::{Z0, P1, P2, P3, P4, P5, P6, P7, P8, P9, N1, N2, N3, N4, N5, N6, N7, N8, N9};
         use $crate::Integer;
-        use $crate::{Dimension, Dimensionless, Dim, Pow, Root, Recip, DimToString};
-        use ::std::ops::{Add, Neg, Sub, Mul, Div};
-        use ::std::marker::PhantomData;
+        use $crate::{Dimension, Dimensionless, Dim, Pow, Root, Recip, FmtDim};
+        use $crate::reexported::ops::{Add, Neg, Sub, Mul, Div};
+        use $crate::reexported::marker::PhantomData;
+        use $crate::reexported::fmt;
 
         #[derive(Copy, Clone)]
         pub struct $System<$($Type: Integer = Z0),*> {
@@ -137,8 +138,8 @@ macro_rules! make_units_adv {
         }
         impl<$($Type: Integer),*> Dimension for $System<$($Type),*> {}
 
-        // using $Type and $constant for these traits is confusing. It should really be $Type_Left and
-        // $Type_Right or something, but that is not yet supported by Rust
+        // using $Type and $constant for these traits is confusing. It should really be $Type_Left
+        // and $Type_Right or something, but that is not yet supported by Rust
         #[allow(non_camel_case_types)]
         impl<$($Type),*, $($constant),*> Mul<$System<$($constant),*>> for $System<$($Type),*>
         where $($Type: Integer + Add<$constant>),*,
@@ -161,18 +162,21 @@ macro_rules! make_units_adv {
         }
 
         // Note that this is backwards from the definition of `Pow`. We should be doing:
-        // impl<$($Type),*, RHS> Pow<$System<$($Type),*>> for RHS
-        // as RHS is really the exponent, but it's in the place of the base. Rust won't let us do that
-        // generically, so we've switched them, as the operation on dimensions is multiplication so it's commutative.
+        // impl<$($Type),*, RHS> Pow<$System<$($Type),*>> for RHS as RHS is really the exponent,
+        // but it's in the place of the base. Rust won't let us do that generically, so we've
+        // switched them, as the operation on dimensions is multiplication so it's commutative.
         impl<$($Type),*, RHS> Pow<RHS> for $System<$($Type),*>
-            where $($Type: Integer + Mul<RHS>),*, RHS: Integer, $(<$Type as Mul<RHS>>::Output: Integer),*
+            where $($Type: Integer + Mul<RHS>),*, RHS: Integer,
+                  $(<$Type as Mul<RHS>>::Output: Integer),*
         {
             type Output = $System<$(<$Type as Mul<RHS>>::Output),*>;
             fn pow(_: RHS) -> Self::Output { unreachable!() }
         }
 
-        impl<$($Type),*, RHS> Root<RHS> for $System<$($Type),*> where
-            $($Type: Integer + Div<RHS>),*, RHS: Integer, $(<$Type as Div<RHS>>::Output: Integer),* {
+        impl<$($Type),*, RHS> Root<RHS> for $System<$($Type),*>
+            where $($Type: Integer + Div<RHS>),*, RHS: Integer,
+                  $(<$Type as Div<RHS>>::Output: Integer),*
+        {
             type Output = $System<$(<$Type as Div<RHS>>::Output),*>;
             fn root(_: RHS) -> Self::Output { unreachable!() }
         }
@@ -183,36 +187,40 @@ macro_rules! make_units_adv {
             fn recip(self) -> Self::Output { unreachable!() }
         }
 
-
-        fn pretty_dim(roots: [i32; count_args!($($Type),*)], exps: [i32; count_args!($($Type),*)], tokens: [&'static str; count_args!($($Type),*)]) -> String {
-            let mut __string = String::new();
-            for ((&root, &exp), &token) in roots.iter().zip(exps.iter()).zip(tokens.iter()) {
-                let __temp: (&'static str, String) = match exp {
-                    0 => ("", "".to_owned()),
-                    _ if exp == root => (token, "*".to_owned()),
-                    _ => {
-                        if exp % root == 0 {
-                            (token, format!("^{}*", exp/root))
-                        } else {
-                            (token, format!("^{:.2}*", exp as f32/root as f32))
-                        }
-                    },
-                };
-                __string = format!("{}{}{}", __string, __temp.0, __temp.1);
-            }
-            __string.pop(); // remove the last "*"
-            __string
-        }
-
-
-        impl<$($Type),*> DimToString for $System<$($Type),*>
-            where $($Type: Integer),* {
-            fn to_string() -> String {
+        impl<$($Type),*> FmtDim for $System<$($Type),*>
+            where $($Type: Integer),*
+        {
+            fn fmt(f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
                 let allowed_roots = [$($Root::to_i32()),*];
                 let exponents = [$($Type::to_i32()),*];
                 let print_tokens = [$(stringify!($print_as)),*];
 
-                pretty_dim(allowed_roots, exponents, print_tokens)
+                let mut first = true;
+
+                for ((&root, &exp), &token) in
+                    allowed_roots.iter()
+                    .zip(exponents.iter())
+                    .zip(print_tokens.iter())
+                {
+                    if first {
+                        first = false;
+                    } else if exp != 0 {
+                        write!(f, "*")?;
+                    }
+
+                    match exp {
+                        0 => (),
+                        _ if exp == root => write!(f, "{}", token)?,
+                        _ => {
+                            if exp % root == 0 {
+                                write!(f, "{}^{}", token, exp/root)?
+                            } else {
+                                write!(f, "{}^{:.2}", token, exp as f32/root as f32)?
+                            }
+                        },
+                    }
+                }
+                Ok(())
             }
         }
 
@@ -223,7 +231,8 @@ macro_rules! make_units_adv {
 
         __make_base_types!($System, $($Type, $Root),+ |);
 
-        $(#[allow(non_upper_case_globals, dead_code)] pub const $constant: Dim<$Type, $OneType> = Dim($val, PhantomData));*;
+        $(#[allow(non_upper_case_globals, dead_code)]
+          pub const $constant: Dim<$Type, $OneType> = Dim($val, PhantomData));*;
 
         $(pub type $Derived = unit!($($derived_rhs)+);
           #[allow(non_upper_case_globals)]
@@ -259,7 +268,8 @@ macro_rules! count_args {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __make_base_types {
-    ($System:ident, $Type:ident, $Root:ident, $($Types:ident, $Roots:ident),+ | $($Zeros:ident),*) => (
+    ($System:ident, $Type:ident, $Root:ident, $($Types:ident, $Roots:ident),+ | $($Zeros:ident),*)
+        => (
         pub type $Type = $System< $($Zeros,)* $Root>;
         __make_base_types!($System, $($Types, $Roots),+ | Z0 $(, $Zeros)*);
         );

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -141,34 +141,42 @@ macro_rules! make_units_adv {
         // $Type_Right or something, but that is not yet supported by Rust
         #[allow(non_camel_case_types)]
         impl<$($Type),*, $($constant),*> Mul<$System<$($constant),*>> for $System<$($Type),*>
-            where $($Type: Integer + Add<$constant>),*,
-        $($constant: Integer),*,
-        $(<$Type as Add<$constant>>::Output: Integer),*,
-        $System<$(<$Type as Add<$constant>>::Output),*>: Dimension,
+        where $($Type: Integer + Add<$constant>),*,
+              $($constant: Integer),*,
+              $(<$Type as Add<$constant>>::Output: Integer),*,
+              $System<$(<$Type as Add<$constant>>::Output),*>: Dimension,
         {
             type Output = $System<$(<$Type as Add<$constant>>::Output),*>;
-            #[allow(unused_variables)]
-            fn mul(self, rhs: $System<$($constant),*>) -> Self::Output { unreachable!()  }
+            fn mul(self, _: $System<$($constant),*>) -> Self::Output { unreachable!()  }
         }
+
         #[allow(non_camel_case_types)]
-        impl<$($Type),*, $($constant),*> Div<$System<$($constant),*>> for $System<$($Type),*> where
-            $($Type: Integer + Sub<$constant>),*, $($constant: Integer),*, $(<$Type as Sub<$constant>>::Output: Integer),* {
+        impl<$($Type),*, $($constant),*> Div<$System<$($constant),*>> for $System<$($Type),*>
+            where $($Type: Integer + Sub<$constant>),*,
+                  $($constant: Integer),*,
+                  $(<$Type as Sub<$constant>>::Output: Integer),*
+        {
             type Output = $System<$(<$Type as Sub<$constant>>::Output),*>;
-            #[allow(unused_variables)]
-            fn div(self, rhs: $System<$($constant),*>) -> Self::Output { unreachable!()  }
+            fn div(self, _: $System<$($constant),*>) -> Self::Output { unreachable!()  }
         }
-        impl<$($Type),*, RHS> Pow<RHS> for $System<$($Type),*> where
-            $($Type: Integer + Mul<RHS>),*, RHS: Integer, $(<$Type as Mul<RHS>>::Output: Integer),* {
+
+        // Note that this is backwards from the definition of `Pow`. We should be doing:
+        // impl<$($Type),*, RHS> Pow<$System<$($Type),*>> for RHS
+        // as RHS is really the exponent, but it's in the place of the base. Rust won't let us do that
+        // generically, so we've switched them, as the operation on dimensions is multiplication so it's commutative.
+        impl<$($Type),*, RHS> Pow<RHS> for $System<$($Type),*>
+            where $($Type: Integer + Mul<RHS>),*, RHS: Integer, $(<$Type as Mul<RHS>>::Output: Integer),*
+        {
             type Output = $System<$(<$Type as Mul<RHS>>::Output),*>;
-            #[allow(unused_variables)]
-            fn pow(rhs: RHS) -> Self::Output { unreachable!() }
+            fn pow(_: RHS) -> Self::Output { unreachable!() }
         }
+
         impl<$($Type),*, RHS> Root<RHS> for $System<$($Type),*> where
             $($Type: Integer + Div<RHS>),*, RHS: Integer, $(<$Type as Div<RHS>>::Output: Integer),* {
             type Output = $System<$(<$Type as Div<RHS>>::Output),*>;
-            #[allow(unused_variables)]
-            fn root(radicand: RHS) -> Self::Output { unreachable!() }
+            fn root(_: RHS) -> Self::Output { unreachable!() }
         }
+
         impl<$($Type),*> Recip for $System<$($Type),*> where
             $($Type: Integer + Neg),*, $(<$Type as Neg>::Output: Integer),* {
             type Output = $System<$(<$Type as Neg>::Output),*>;
@@ -200,8 +208,6 @@ macro_rules! make_units_adv {
         impl<$($Type),*> DimToString for $System<$($Type),*>
             where $($Type: Integer),* {
             fn to_string() -> String {
-                // fixme: add #[allow(unused_variables)] lints for these. Not working
-                // for me for some reason.
                 let allowed_roots = [$($Root::to_i32()),*];
                 let exponents = [$($Type::to_i32()),*];
                 let print_tokens = [$(stringify!($print_as)),*];
@@ -217,7 +223,7 @@ macro_rules! make_units_adv {
 
         __make_base_types!($System, $($Type, $Root),+ |);
 
-        $(#[allow(non_upper_case_globals)] pub const $constant: Dim<$Type, $OneType> = Dim($val, PhantomData));*;
+        $(#[allow(non_upper_case_globals, dead_code)] pub const $constant: Dim<$Type, $OneType> = Dim($val, PhantomData));*;
 
         $(pub type $Derived = unit!($($derived_rhs)+);
           #[allow(non_upper_case_globals)]

--- a/src/unit_systems/cgs.rs
+++ b/src/unit_systems/cgs.rs
@@ -1,9 +1,8 @@
-/*!
-The **cgs** module provides a unit system for use with Gaussian CGS units. It was
-generated using the `make_units!` macro. See its documentation for more information.
-
-It will also define derived units, although this is not implemented yet.
-*/
+//! The **cgs** module provides a unit system for use with Gaussian CGS units. It was
+//! generated using the `make_units!` macro. See its documentation for more information.
+//!
+//! It will also define derived units, although this is not implemented yet.
+//!
 
 #![allow(missing_docs)]
 
@@ -19,15 +18,33 @@ make_units_adv! {
     }
 }
 
-pub trait FromCGS<Centimeter: Integer, Gram: Integer, Second: Integer, V> where Self: Sized {
+pub trait FromCGS<Centimeter: Integer, Gram: Integer, Second: Integer, V>
+    where Self: Sized
+{
     fn from_cgs(from: Dim<CGS<Centimeter, Gram, Second>, V>) -> Dim<Self, V>;
 }
 
+#[allow(unused_imports)]
+// needed for some reason
+#[cfg(not(feature="std"))]
+use core::num::Float;
+
+#[allow(unused_imports)]
+// needed for some reason
+#[cfg(not(feature="std"))]
+use dim::Sqrt;
+
 use mks::{MKS, FromMKS};
-impl<Meter, Kilogram, Second, V> FromMKS<Meter, Kilogram, Second, V> for CGS<Meter, Kilogram, Second>
-    where V: Mul<f64, Output=V>, Meter: Integer, Kilogram: Integer, Second: Integer, {
+impl<Meter, Kilogram, Second, V> FromMKS<Meter, Kilogram, Second, V>
+    for CGS<Meter, Kilogram, Second>
+    where V: Mul<f64, Output = V>,
+          Meter: Integer,
+          Kilogram: Integer,
+          Second: Integer
+{
     fn from_mks(from: Dim<MKS<Meter, Kilogram, Second>, V>) -> Dim<Self, V> {
-        Dim::new( from.0 * 100f64.sqrt().powi(Meter::to_i32()) * 1000f64.sqrt().powi(Kilogram::to_i32()) )
+        Dim::new(from.0 * 100f64.sqrt().powi(Meter::to_i32()) *
+                 1000f64.sqrt().powi(Kilogram::to_i32()))
     }
 }
 
@@ -37,5 +54,5 @@ fn gal_test() {
     let x = 3.0 * cm;
     let t = 2.0 * s;
     let a = 4.5 * gal;
-    assert_eq!(a, x*x/t);
+    assert_eq!(a, x * x / t);
 }

--- a/src/unit_systems/mks.rs
+++ b/src/unit_systems/mks.rs
@@ -1,9 +1,8 @@
-/*!
-The **mks** module provides a unit system for use with Gaussian MKS units. It was
-generated using the `make_units!` macro. See its documentation for more information.
-
-It will also define derived units, although this is not implemented yet.
-*/
+//! The **mks** module provides a unit system for use with Gaussian MKS units. It was
+//! generated using the `make_units!` macro. See its documentation for more information.
+//!
+//! It will also define derived units, although this is not implemented yet.
+//!
 
 #![allow(missing_docs)]
 
@@ -18,14 +17,32 @@ make_units_adv! {
     }
 }
 
-pub trait FromMKS<Meter: Integer, Kilogram: Integer, Second: Integer, V> where Self: Sized {
+pub trait FromMKS<Meter: Integer, Kilogram: Integer, Second: Integer, V>
+    where Self: Sized
+{
     fn from_mks(from: Dim<MKS<Meter, Kilogram, Second>, V>) -> Dim<Self, V>;
 }
 
+#[allow(unused_imports)]
+// needed for some reason
+#[cfg(not(feature="std"))]
+use core::num::Float;
+
+#[allow(unused_imports)]
+// needed for some reason
+#[cfg(not(feature="std"))]
+use dim::Sqrt;
+
 use cgs::{CGS, FromCGS};
-impl<Centimeter, Gram, Second, V> FromCGS<Centimeter, Gram, Second, V> for MKS<Centimeter, Gram, Second>
-    where V: Mul<f64, Output=V>, Centimeter: Integer, Gram: Integer, Second: Integer, {
+impl<Centimeter, Gram, Second, V> FromCGS<Centimeter, Gram, Second, V>
+    for MKS<Centimeter, Gram, Second>
+    where V: Mul<f64, Output = V>,
+          Centimeter: Integer,
+          Gram: Integer,
+          Second: Integer
+{
     fn from_cgs(from: Dim<CGS<Centimeter, Gram, Second>, V>) -> Dim<Self, V> {
-        Dim::new( from.0 * 0.01f64.sqrt().powi(Centimeter::to_i32()) * 0.001f64.sqrt().powi(Gram::to_i32()) )
+        Dim::new(from.0 * 0.01f64.sqrt().powi(Centimeter::to_i32()) *
+                 0.001f64.sqrt().powi(Gram::to_i32()))
     }
 }

--- a/src/unit_systems/si.rs
+++ b/src/unit_systems/si.rs
@@ -1,9 +1,8 @@
-/*!
-The **si** module provides a unit system for use with SI units. It was generated using
-the `make_units!` macro. See its documentation for more information.
-
-It will also define derived units, although this is not implemented yet.
-*/
+//! The **si** module provides a unit system for use with SI units. It was generated using
+//! the `make_units!` macro. See its documentation for more information.
+//!
+//! It will also define derived units, although this is not implemented yet.
+//!
 
 #![allow(missing_docs)]
 

--- a/tests/derived.rs
+++ b/tests/derived.rs
@@ -1,4 +1,3 @@
-#![feature(type_macros)]
 #[macro_use]
 extern crate dimensioned as dim;
 

--- a/tests/derived.rs
+++ b/tests/derived.rs
@@ -5,7 +5,6 @@ extern crate dimensioned as dim;
 use dim::Dim;
 use dim::si::{Meter, Second};
 use std::ops::Div;
-use std::marker::PhantomData;
 
 type MPS = unit!(Meter / Second);
 


### PR DESCRIPTION
This adds a `std` default feature. When disabled, dimensioned reverts to dependency on `core` only.

It would be nice get rid of any `std` dependency, but there's some funky things that have to be done to make `core` work, so let's keep `std` as the default for now.