### PR TITLE
Int consts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 This project follows semantic versioning.
 
+### Unpublished
+- [added] Modules for integer constants to `make_units!` macro.
+
 ### 0.6.0 (2017-03-03)
-- `[changed]` ***BREAKING*** Dimensioned has been rewritten from the ground up. It still does the
+- [changed] ***BREAKING*** Dimensioned has been rewritten from the ground up. It still does the
   same thing but the internals are completely different. Read about it
   [here](http://paholg.com/2017/03/03/dimensioned_0.6/).
 
 ### 0.5.0 (2015-12-02)
-- `[added]` This change log!
-- `[changed]` ***BREAKING*** Use typenum instead of peano for faster and more complete type-level
+- [added] This change log!
+- [changed] ***BREAKING*** Use typenum instead of peano for faster and more complete type-level
   numbers. ([PR #3](https://github.com/paholg/dimensioned/pull/3))
-- `[added]` Re-export useful things from typenum so that crates downstream don't need to depend on
+- [added] Re-export useful things from typenum so that crates downstream don't need to depend on
   it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ Never again should you need to specify units in a comment!"""
 [dependencies]
   typenum = "1.6.0"
   generic-array = "0.5.1"
-  clippy = { version = "0.0.122", optional = true }
+  clippy = { version = "0.0.135", optional = true }
   quickcheck = { version = "0.4.1", optional = true }
   quickcheck_macros = { version = "0.4.1", optional = true }
   approx = { version = "0.1.1", optional = true, features = ["no_std"] }

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -305,6 +305,34 @@ macro_rules! make_units {
         define_consts!(f32consts, f32prefixes, f32);
         define_consts!(f64consts, f64prefixes, f64);
 
+        macro_rules! define_int_consts {
+            ($module:ident, $t:ident) => (
+                /// Constants defined for this system
+                pub mod $module {
+                    use super::*;
+                    use $crate::dimcore::marker::PhantomData;
+                    #[allow(dead_code, missing_docs)]
+                    pub const $one: $Unitless<$t> = $System { value_unsafe: 1, _marker: PhantomData };
+                    $(#[allow(dead_code, missing_docs)]
+                      pub const $base: $Unit<$t> = $System { value_unsafe: 1, _marker: PhantomData };)*
+                    $(#[allow(dead_code, missing_docs)]
+                      pub const $derived_const: $Derived<$t> = $System { value_unsafe: 1, _marker: PhantomData };)*
+                }
+            );
+        }
+        define_int_consts!(i8consts, i8);
+        define_int_consts!(i16consts, i16);
+        define_int_consts!(i32consts, i32);
+        define_int_consts!(i64consts, i64);
+        define_int_consts!(isize_consts, isize);
+
+        define_int_consts!(u8consts, u8);
+        define_int_consts!(u16consts, u16);
+        define_int_consts!(u32consts, u32);
+        define_int_consts!(u64consts, u64);
+        define_int_consts!(usize_consts, usize);
+
+
         // --------------------------------------------------------------------------------
         // Formatting
         use $crate::dimcore::fmt;


### PR DESCRIPTION
Add initial, incomplete integer constant modules. These only include constants defined in `base` and `derived`. As the `constants` block may include floats, it cannot be used. We should add an optional `int_consts` block.