### PR TITLE
Add serde support behind a feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ Never again should you need to specify units in a comment!"""
   default = []
   oibit = []
   spec = []
-  test = ["clippy", "quickcheck", "quickcheck_macros", "approx", "oibit", "spec"]
+  test = ["clippy", "quickcheck", "quickcheck_macros", "approx", "oibit", "spec", "serde", "serde_test"]
 
 [dependencies]
   typenum = "1.6.0"
@@ -33,3 +33,5 @@ Never again should you need to specify units in a comment!"""
   quickcheck = { version = "0.4.1", optional = true }
   quickcheck_macros = { version = "0.4.1", optional = true }
   approx = { version = "0.1.1", optional = true, features = ["no_std"] }
+  serde = { version = "1.0.0", optional = true }
+  serde_test = { version = "1.0.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,9 @@ pub extern crate generic_array;
 #[cfg(feature = "approx")]
 pub extern crate approx;
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
 #[macro_use] mod make_units;
 mod fmt;
 

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -489,6 +489,35 @@ macro_rules! make_units {
                 self.value_unsafe.ulps_ne(&other.value_unsafe, epsilon.value_unsafe, max_ulps)
             }
         }
+
+        // --------------------------------------------------------------------------------
+        // Serde
+        #[cfg(feature = "serde")]
+        use $crate::serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+        #[cfg(feature = "serde")]
+        impl<'de, V, U> Deserialize<'de> for $System<V, U>
+            where V: Deserialize<'de>
+        {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where D: Deserializer<'de>
+            {
+                let value_unsafe = V::deserialize(deserializer)?;
+                Ok($System{ value_unsafe, _marker: marker::PhantomData })
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<V, U> Serialize for $System<V, U>
+            where V: Serialize
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where S: Serializer
+            {
+                self.value_unsafe.serialize(serializer)
+            }
+        }
+
         // --------------------------------------------------------------------------------
     );
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,17 @@
+#![cfg(feature = "serde")]
+
+extern crate dimensioned as dim;
+extern crate serde;
+extern crate serde_test;
+
+use dim::si;
+use serde_test::{assert_tokens, Token};
+
+#[test]
+fn serialization() {
+    let dist = 6.0 * si::M;
+    assert_tokens(&dist, &[Token::F64(6.0)]);
+
+    let speed = 2.0 * si::MPS;
+    assert_tokens(&speed, &[Token::F64(2.0)]);
+}


### PR DESCRIPTION
This turned out to be pretty simple to implement, although I do have a few questions:
- Did I get the feature flags right? Should serde_test be a dev-dependency, or does it not really matter since it's optional?
- When running `$ cargo test --feature "serde serde_test"`, one of the doc tests fails. It's not clear to me why, since the error originates in some generated code. What can I do about that?