### PR TITLE
Fix no-std of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
   name = "dimensioned"
-  version = "0.6.0"
+  version = "0.6.1"
   authors = ["Paho Lurie-Gregg <paho@paholg.com>"]
   documentation = "http://paholg.com/dimensioned"
   repository = "https://github.com/paholg/dimensioned"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ Never again should you need to specify units in a comment!"""
 
 [dependencies]
   typenum = "1.6.0"
-  generic-array = "0.5.1"
+  generic-array = "0.6.0"
   clippy = { version = "0.0.135", optional = true }
   quickcheck = { version = "0.4.1", optional = true }
   quickcheck_macros = { version = "0.4.1", optional = true }

--- a/src/array.rs
+++ b/src/array.rs
@@ -43,7 +43,7 @@ pub trait ToGA {
 impl ToGA for ATerm {
     type Output = GenericArray<isize, U0>;
     fn to_ga() -> Self::Output {
-        GenericArray::new()
+        GenericArray::default()
     }
 }
 
@@ -95,7 +95,7 @@ impl<T, N> AppendFront<T> for GenericArray<T, N>
 {
     type Output = GenericArray<T, Add1<N>>;
     fn append_front(self, element: T) -> Self::Output {
-        let mut a = GenericArray::new();
+        let mut a = GenericArray::default();
         a[0] = element;
         for (i, el) in self.into_iter().enumerate() {
             a[i + 1] = el;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -41,7 +41,8 @@ mod to_si {
         V: Mul<f64>,
     {
         fn from(other: ucum::UCUM<V, tarr![Meter, Second, Gram, Z0, Kelvin, Coulomb, Candela]>) -> Self {
-            let gfac = MILLI.powi(Gram::to_i32());
+            use core::intrinsics::powif64;
+            let gfac = unsafe { powif64(MILLI, Gram::to_i32()) };
 
             let fac = gfac;
 
@@ -66,7 +67,8 @@ mod to_ucum {
         V: Mul<f64>,
     {
         fn from(other: si::SI<V, tarr![Meter, Kilogram, Second, Ampere, Kelvin, Candela, Z0]>) -> Self {
-            let kgfac = KILO.powi(Kilogram::to_i32());
+            use core::intrinsics::powif64;
+            let kgfac = unsafe { powif64(KILO, Kilogram::to_i32()) };
 
             let fac = kgfac;
 
@@ -89,13 +91,14 @@ mod to_cgs {
         V: Mul<f64>,
     {
         fn from(other: mks::MKS<V, tarr![SqrtMeter, SqrtKilogram, Second]>) -> Self {
+            use core::intrinsics::{powif64, sqrtf64};
             let mfac = match SqrtMeter::to_i32() {
-                e if e % 2 == 0 => HECTO.powi(e / 2),
-                e => HECTO.sqrt().powi(e),
+                e if e % 2 == 0 => unsafe { powif64(HECTO, e / 2) },
+                e => unsafe { powif64(sqrtf64(HECTO), e) },
             };
             let kgfac = match SqrtKilogram::to_i32() {
-                e if e % 2 == 0 => KILO.powi(e / 2),
-                e => KILO.sqrt().powi(e),
+                e if e % 2 == 0 => unsafe { powif64(KILO, e / 2) },
+                e => unsafe { powif64(sqrtf64(KILO), e) },
             };
 
             let fac = mfac * kgfac;
@@ -145,13 +148,14 @@ mod to_mks {
         V: Mul<f64>,
     {
         fn from(other: cgs::CGS<V, tarr![SqrtCentimeter, SqrtGram, Second]>) -> Self {
+            use core::intrinsics::{powif64, sqrtf64};
             let cmfac = match SqrtCentimeter::to_i32() {
-                e if e % 2 == 0 => CENTI.powi(e/2),
-                e => CENTI.sqrt().powi(e),
+                e if e % 2 == 0 => unsafe { powif64(CENTI, e / 2) },
+                e => unsafe { powif64(sqrtf64(CENTI), e) },
             };
             let gfac = match SqrtGram::to_i32() {
-                e if e % 2 == 0 => MILLI.powi(e / 2),
-                e => MILLI.sqrt().powi(e),
+                e if e % 2 == 0 => unsafe { powif64(MILLI, e / 2) },
+                e => unsafe { powif64(sqrtf64(MILLI), e) },
             };
 
             let fac = cmfac * gfac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ crate. Pretty much everything else is for ergonomics.
        html_favicon_url = "https://raw.githubusercontent.com/paholg/dimensioned/master/favicon.png",
        html_root_url = "http://paholg.com/dimensioned")]
 
+#![feature(core_intrinsics)]
 #![no_std]
 
 #![warn(missing_docs)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -201,7 +201,8 @@ macro_rules! impl_root {
 
             fn root(self, _: Index) -> Self::Output {
                 let exp = (Index::to_i32() as $t).recip();
-                self.powf(exp)
+                use core::intrinsics::$f;
+                unsafe { $f(self, exp) }
             }
         }
     );
@@ -250,6 +251,21 @@ pub trait Sqrt {
     fn sqrt(self) -> Self::Output;
 }
 
+macro_rules! impl_sqrt {
+    ($t: ty, $f: ident) => (
+        impl Sqrt for $t {
+            type Output = $t;
+            fn sqrt(self) -> Self::Output {
+                use core::intrinsics::$f;
+                unsafe { $f(self) }
+            }
+        }
+    );
+}
+
+impl_sqrt!(f32, sqrtf32);
+impl_sqrt!(f64, sqrtf64);
+
 /// `Cbrt` provides a `cbrt` member function for types that are not necessarily preserved under
 /// cube root.
 ///
@@ -276,23 +292,18 @@ pub trait Cbrt {
     fn cbrt(self) -> Self::Output;
 }
 
-macro_rules! impl_sqcbroot {
-    ($t: ty) => (
-        impl Sqrt for $t {
-            type Output = $t;
-            fn sqrt(self) -> Self::Output {
-                self.sqrt()
-            }
-        }
-
+macro_rules! impl_cbrt {
+    ($t: ty, $f: ident) => (
         impl Cbrt for $t {
             type Output = $t;
             fn cbrt(self) -> Self::Output {
-                self.cbrt()
+                let exp = (3 as $t).recip();
+                use core::intrinsics::$f;
+                unsafe { $f(self, exp) }
             }
         }
     );
 }
 
-impl_sqcbroot!(f32);
-impl_sqcbroot!(f64);
+impl_cbrt!(f32, powf32);
+impl_cbrt!(f64, powf64);


### PR DESCRIPTION
I was having trouble compiling `0.6.0` in a `no_std` environment, because the version of `generic-array` it depended on (which was very old) wasn't `no_std`. All I did in these changes is bump the version of `generic-array` the minimum I could to resolve this. a4a8fe2 then fixes the few breaking API changes. f76208c was necessary because the `pow*` and `sqrt` functions are part of `std` and didn't exist in the `no_std` environment, so I had to replace them with their counterparts in `core::intrinsics`. I made this a minor version bump because the API doesn't change at all.