### PR TITLE
Bump required rustc version to 1.23.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ branches:
 
 matrix:
   include:
+    - rust: 1.23.0
+      script: |
+        cargo build
+        cargo test --features "test"
+        cargo doc
     - rust: stable
       before_script:
         - rustup component add rustfmt-preview

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Its goal is to provide zero cost unit safety while requiring minimal effort from
 
 # Use
 
-Dimensioned requires at least Rust version 1.15. It does not depend on `std`.
+Dimensioned requires at least Rust version 1.23.0 (and is tested on this version).
+
+It does not depend on `std`; simple include without the default feature `std`. Doing so requires a
+nightly version of rustc.
 
 If you are using Rust nightly, then you may enable the "oibit" feature of dimensioned. This will
 make it work a bit better for wrapping non-primitives in units. The recommended way to use


### PR DESCRIPTION
Dimensioned doesn't build on 1.15.0 anymore; we should not lie about it.
To that end, let's also build it on this minimum version.