### PR TITLE
Replace transmutes with pointer casts (#52)

### DIFF
--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -484,7 +484,7 @@ macro_rules! make_units {
             #[inline]
             fn index(&self, index: Idx) -> &Self::Output {
                 unsafe {
-                    $crate::dimcore::mem::transmute(&self.value_unsafe[index])
+                    &*(&self.value_unsafe[index] as *const V::Output as *const Self::Output)
                 }
             }
         }
@@ -499,7 +499,7 @@ macro_rules! make_units {
             #[inline]
             fn index_mut(&mut self, index: Idx) -> &mut Self::Output{
                 unsafe {
-                    $crate::dimcore::mem::transmute(self.value_unsafe.index_mut(index))
+                    &mut *(self.value_unsafe.index_mut(index) as *mut V::Output as *mut Self::Output)
                 }
             }
         }


### PR DESCRIPTION
Here's an option to get rid of the `transmutes`, based on the [alternatives](https://doc.rust-lang.org/std/mem/fn.transmute.html#alternatives) section of the docs. We cast a reference to a pointer, then cast to a different pointer type, and then use `unsafe` to cast that pointer back to a reference.