### PR TITLE
Added support of use with `no_std` on Rust's `stable` channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
         set -e
         cargo clippy --version
         cargo clippy
-        cargo test --no-default-features --features "ci"
+        cargo test --no-default-features --features "ci nightly"
         cargo test --all-features
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project follows semantic versioning.
 
 ### Unpublished
 
+### 0.8.0 (2019-03-13)
+- [changed] ***BREAKING*** Reduced requirement of nightly for use in `no_std` (as introduced in 0.7.0) down to just unit system conversions and `Sqrt`/`Root` traits. Everything else now works with `no_std` on stable!
+  Using unit system conversions and/or `Sqrt`/`Root` traits without `std` now requires nightly Rust and the `nightly` feature. Just like with 0.7.0 I don't think this will actually break anything, as things that were not working before on stable now are working, but is at least a break in the intended way to use `dimensioned` without `std`. Again, once `sqrt`, `powf`, and `cbrt` are usable without std on stable, the nightly requirement can be removed.
+- [changed] ***BREAKING*** Updated dependency `rand` from "0.5.4" to "0.6.5".
+- [changed] ***BREAKING*** Updated dependency `quickcheck` from "0.6.2" to "0.8.2".
+- [changed] ***BREAKING*** Updated dependency `generic-array` from "0.11.0" to "0.12.0".
+
 ### 0.7.0 (2018-08-12)
 - [changed] ***BREAKING*** Made dimensioned work with `no_std` again, and added the default feature
   `std`. Using this without `std` now requires nightly Rust and using `dimensioned` without default

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ Never again should you need to specify units in a comment!"""
   oibit = []
   spec = []
   std = []
+  nightly = []
   test = [ "approx", "ci", "clapme", "quickcheck", "serde", "serde_test", "rand"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
   name = "dimensioned"
-  version = "0.7.0"
+  version = "0.8.0"
   authors = ["Paho Lurie-Gregg <paho@paholg.com>"]
   documentation = "https://docs.rs/dimensioned"
   repository = "https://github.com/paholg/dimensioned"
@@ -32,10 +32,10 @@ Never again should you need to specify units in a comment!"""
 [dependencies]
   approx = { version = "0.3.0", optional = true, default-features = false }
   clapme = { version = "0.1.1", optional = true }
-  generic-array = "0.11.1"
+  generic-array = "0.12.0"
   num-traits = { version = "0.2.5", default-features = false }
-  quickcheck = { version = "0.6.2", optional = true }
+  quickcheck = { version = "0.8.2", optional = true }
   serde = { version = "1.0.0", optional = true }
   serde_test = { version = "1.0.0", optional = true }
-  rand = { version = "0.5.4", optional = true }
+  rand = { version = "0.6.5", optional = true }
   typenum = "1.6.0"

--- a/README.md
+++ b/README.md
@@ -70,16 +70,24 @@ fn generic_speed<L, T>(dist: L, time: T) -> Quot<L, T>
 }
 
 fn main() {
-    let x = 6.0 * si::M;
-    let t = 3.0 * si::S;
-    let v = 2.0 * si::M/si::S;
-    let v2 = speed(x, t);
-    assert_eq!(v, v2);
+    let si_x = 6.0 * si::M;
+    let si_t = 3.0 * si::S;
+    let si_v = 2.0 * si::M / si::S;
 
-    let v3 = generic_speed(6.0 * cgs::M, 3.0 * cgs::S);
-    let v4 = v.into();
-    assert_eq!(v3, v4);
+    let si_v2 = speed(si_x, si_t);
+    assert_eq!(si_v, si_v2);
+
+    let cgs_x = 6.0 * cgs::M;
+    let cgs_t = 3.0 * cgs::S;
+    let cgs_v = 2.0 * cgs::M / cgs::S;
+
+    let cgs_v2 = generic_speed(cgs_x, cgs_t);
+    assert_eq!(cgs_v, cgs_v2);
+
+    let si_v3 = cgs_v2.into();
+    assert_eq!(si_v2, si_v3);
 }
+
 ```
 
 This example is also included as `examples/readme-example.rs`.

--- a/examples/readme-example.rs
+++ b/examples/readme-example.rs
@@ -1,4 +1,8 @@
+#![allow(unused_imports)]
+
 extern crate dimensioned as dim;
+
+use std::fmt::Debug;
 
 use dim::{cgs, si};
 
@@ -20,14 +24,34 @@ where
     dist / time
 }
 
-fn main() {
-    let x = 6.0 * si::M;
-    let t = 3.0 * si::S;
-    let v = 2.0 * si::M / si::S;
-    let v2 = speed(x, t);
-    assert_eq!(v, v2);
+// Conversion between unit systems is not yet available on stable 'no_std':
+#[cfg(any(feature = "std", feature = "nightly"))]
+fn test_conversion<V1, V2>(v1: V1, v2: V2)
+where
+    V1: From<V2> + PartialEq + Debug,
+{
+    let v3 = v2.into();
+    assert_eq!(v1, v3);
+}
 
-    let v3 = generic_speed(6.0 * cgs::M, 3.0 * cgs::S);
-    let v4 = v.into();
-    assert_eq!(v3, v4);
+// Dummy to skip on `no_std` without `nightly`:
+#[cfg(not(any(feature = "std", feature = "nightly")))]
+fn test_conversion<V1, V2>(_v1: V1, _v2: V2) {}
+
+fn main() {
+    let si_x = 6.0 * si::M;
+    let si_t = 3.0 * si::S;
+    let si_v = 2.0 * si::M / si::S;
+
+    let si_v2 = speed(si_x, si_t);
+    assert_eq!(si_v, si_v2);
+
+    let cgs_x = 6.0 * cgs::M;
+    let cgs_t = 3.0 * cgs::S;
+    let cgs_v = 2.0 * cgs::M / cgs::S;
+
+    let cgs_v2 = generic_speed(cgs_x, cgs_t);
+    assert_eq!(cgs_v, cgs_v2);
+
+    test_conversion(si_v2, si_v2);
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -4,7 +4,7 @@
 //!
 //! Consider this module **unstable**.
 
-use typenum::{ATerm, Add1, B1, Integer, Len, Length, TArr, U0, Unsigned};
+use typenum::{ATerm, Add1, Integer, Len, Length, TArr, Unsigned, B1, U0};
 
 use generic_array::{ArrayLength, GenericArray};
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -478,7 +478,8 @@ more information.
 
 */
 
-pub mod unit_systems {"#.as_bytes(),
+pub mod unit_systems {"#
+            .as_bytes(),
     ).unwrap();
 
     for s in &systems {

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -25,7 +25,7 @@
 //! * `CGS` to `MKS`
 //! * `MKS` to `CGS`
 
-mod to_si {
+mod ucum_to_si {
     // From UCUM
     use core::convert::From;
     use core::ops::{Add, Mul};
@@ -59,7 +59,7 @@ mod to_si {
     }
 }
 
-mod to_ucum {
+mod si_to_ucum {
     // From SI
     use core::convert::From;
     use core::ops::{Mul, Sub};
@@ -96,16 +96,19 @@ mod to_ucum {
     }
 }
 
-mod to_cgs {
+#[cfg(any(feature = "std", feature = "nightly"))]
+mod mks_to_cgs {
     use cgs::CGS;
+
     // From MKS
     use core::convert::From;
-    use core::ops::{Add, Mul};
+    use core::ops::Mul;
     use f64prefixes::*;
     use mks;
     use num_traits::float::FloatCore;
     use traits::Sqrt;
-    use typenum::{Integer, Prod, Sum};
+    use typenum::{Integer, Prod};
+
     impl<V, SqrtMeter, SqrtKilogram, Second>
         From<mks::MKS<V, tarr![SqrtMeter, SqrtKilogram, Second]>>
         for CGS<Prod<V, f64>, tarr![SqrtMeter, SqrtKilogram, Second]>
@@ -130,10 +133,21 @@ mod to_cgs {
             CGS::new(other.value_unsafe * fac)
         }
     }
+}
+
+#[cfg(any(feature = "std", feature = "nightly"))]
+mod si_to_cgs {
+    use cgs::CGS;
+
+    use core::convert::From;
+    use core::ops::{Add, Mul};
+    use mks;
+    use typenum::{Integer, Prod, Sum};
 
     // From SI
     use si;
     use typenum::{P2, P3, Z0};
+
     impl<V, Meter, Kilogram, Second, Ampere>
         From<si::SI<V, tarr![Meter, Kilogram, Second, Ampere, Z0, Z0, Z0]>>
         for CGS<
@@ -163,16 +177,19 @@ mod to_cgs {
     }
 }
 
-mod to_mks {
+#[cfg(any(feature = "std", feature = "nightly"))]
+mod cgs_to_mks {
     use core::convert::From;
-    use core::ops::{Add, Mul};
+    use core::ops::Mul;
     use f64prefixes::*;
     use mks::MKS;
     use num_traits::float::FloatCore;
     use traits::Sqrt;
-    use typenum::{Integer, Prod, Sum};
+    use typenum::{Integer, Prod};
+
     // From CGS
     use cgs;
+
     impl<V, SqrtCentimeter, SqrtGram, Second>
         From<cgs::CGS<V, tarr![SqrtCentimeter, SqrtGram, Second]>>
         for MKS<Prod<V, f64>, tarr![SqrtCentimeter, SqrtGram, Second]>
@@ -197,10 +214,18 @@ mod to_mks {
             MKS::new(other.value_unsafe * fac)
         }
     }
+}
+
+mod si_to_mks {
+    use core::convert::From;
+    use core::ops::{Add, Mul};
+    use mks::MKS;
+    use typenum::{Integer, Prod, Sum};
 
     // From SI
     use si;
     use typenum::{P2, P3, Z0};
+
     impl<V, Meter, Kilogram, Second, Ampere>
         From<si::SI<V, tarr![Meter, Kilogram, Second, Ampere, Z0, Z0, Z0]>>
         for MKS<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,10 @@ crate. Pretty much everything else is for ergonomics.
 #![deny(clippy)]
 #![cfg_attr(feature = "ci", deny(warnings))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(core_intrinsics, extern_prelude))]
+#![cfg_attr(
+    all(not(feature = "std"), feature = "nightly"),
+    feature(core_intrinsics, extern_prelude)
+)]
 #![cfg_attr(feature = "oibit", feature(optin_builtin_traits))]
 #![cfg_attr(feature = "spec", feature(specialization))]
 #![cfg_attr(feature = "cargo-clippy", allow(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,11 @@ crate. Pretty much everything else is for ergonomics.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
     all(not(feature = "std"), feature = "nightly"),
-    feature(core_intrinsics, extern_prelude)
+    feature(core_intrinsics)
+)]
+#![cfg_attr(
+    all(not(feature = "std"), not(feature = "nightly")),
+    feature(extern_prelude)
 )]
 #![cfg_attr(feature = "oibit", feature(optin_builtin_traits))]
 #![cfg_attr(feature = "spec", feature(specialization))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,14 +109,6 @@ crate. Pretty much everything else is for ergonomics.
 #![deny(clippy)]
 #![cfg_attr(feature = "ci", deny(warnings))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(
-    all(not(feature = "std"), feature = "nightly"),
-    feature(core_intrinsics)
-)]
-#![cfg_attr(
-    all(not(feature = "std"), not(feature = "nightly")),
-    feature(extern_prelude)
-)]
 #![cfg_attr(feature = "oibit", feature(optin_builtin_traits))]
 #![cfg_attr(feature = "spec", feature(specialization))]
 #![cfg_attr(feature = "cargo-clippy", allow(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -208,12 +208,15 @@ impl_abs!(isize);
 /// extern crate dimensioned as dim;
 ///
 /// fn main() {
+/// # #[cfg(any(feature = "std", feature = "nightly"))]
+/// # {
 ///     use dim::Root;
 ///     use dim::typenum::P2;
 ///     let x = 4.0.root(P2::new());
 ///     let y = 2.0;
 ///
-///    assert_eq!(x, y);
+///     assert_eq!(x, y);
+/// # }
 /// }
 /// ```
 pub trait Root<Index> {
@@ -248,10 +251,11 @@ macro_rules! impl_root {
 impl_root!(f32, powf32);
 impl_root!(f64, powf64);
 
+#[cfg(any(feature = "std", feature = "nightly"))]
 #[test]
 fn test_root() {
     use typenum::consts::*;
-    let radicands = &[0.0, 0.5, 1.0, 2.0];
+    let radicands: &[f32] = &[0.0, 0.5, 1.0, 2.0];
 
     for &r in radicands {
         assert_eq!(r, r.root(P1::new()));
@@ -270,12 +274,15 @@ fn test_root() {
 /// extern crate dimensioned as dim;
 ///
 /// fn main() {
+/// # #[cfg(any(feature = "std", feature = "nightly"))]
+/// # {
 ///     use dim::si;
 ///     let x = 2.0 * si::M;
 ///     let a = 4.0 * si::M2;
 ///
 ///     use dim::Sqrt;
 ///     assert_eq!(a.sqrt(), x);
+/// # }
 /// }
 /// ```
 pub trait Sqrt {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -224,9 +224,12 @@ pub trait Root<Index> {
     fn root(self, idx: Index) -> Self::Output;
 }
 
+#[cfg(any(feature = "std", feature = "nightly"))]
 use typenum::Integer;
+
 macro_rules! impl_root {
     ($t:ty, $f:ident) => {
+        #[cfg(any(feature = "std", feature = "nightly"))]
         impl<Index: Integer> Root<Index> for $t {
             type Output = $t;
 
@@ -313,6 +316,7 @@ pub trait Cbrt {
 
 macro_rules! impl_sqcbroot {
     ($t:ty, $f:ident, $nan:path) => {
+        #[cfg(any(feature = "std", feature = "nightly"))]
         impl Sqrt for $t {
             type Output = $t;
             fn sqrt(self) -> Self::Output {


### PR DESCRIPTION
Moved impls of `Root` and `Sqrt` traits, as well as any unit system conversions using them, behind an additional `nightly` feature flag.

This allows one to use **dimensioned** on stable with `no_std` as long as you don't try to convert between one unit system and another. I'd reckon that most people pick one system and then stick to it anyway.

I'd like to use **dimensioned** in a project that targets embedded environments, but make use of the fact that `no_std` by itself doesn't require nightly any more.

To use unit system conversions on `no_std` one now has to pass an additional `--features=nightly` (in addition to `--no-default-features`) to `cargo build`.