### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -16,7 +16,7 @@ macro_rules! format_cgs_like {
 
                 let mut first = true;
                 for (&exp, token) in
-                    exponents.into_iter()
+                    exponents.iter()
                     .zip(print_tokens.iter())
                 {
                     if first {


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
