### PR TITLE
Add static method System::to_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project follows semantic versioning.
 
 ### Unpublished
 - [fixed] A compilation error with the `rand` feature.
+- [added] The optional `auto-args` feature to derive argument parsing.
+- [added] The static method `to_string`.
 
 ### 0.8.0 (2019-03-13)
 - [changed] ***BREAKING*** Reduced requirement of nightly for use in `no_std`

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -263,6 +263,7 @@ macro_rules! make_units {
             /// Output the units of this type in the same format as in the
             /// formatting traits.
             #[inline]
+            #[cfg(feature = "std")]
             pub fn to_string() -> String {
                 struct Displayer<U2>(PhantomData<U2>);
                 impl<U2> fmt::Display for Displayer<U2>

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -189,7 +189,7 @@ macro_rules! make_units {
      }
      fmt = $to_fmt:ident;
     ) => (
-        use $crate::dimcore::marker;
+        use $crate::dimcore::marker::PhantomData;
         use $crate::{Dimensioned, Dimensionless};
 
         /// The struct for this unit system
@@ -216,7 +216,7 @@ macro_rules! make_units {
             ///
             /// Once `const_fns` is stabilized, that will be able to be replaced with a call to
             /// `Meter::new` and `_marker` will be made private.
-            pub _marker: marker::PhantomData<U>,
+            pub _marker: PhantomData<U>,
         }
 
         impl<V, U> $System<V, U> {
@@ -224,7 +224,59 @@ macro_rules! make_units {
             /// Create a new quantity in the $System unit system
             #[inline]
             pub fn new(v: V) -> Self {
-                $System { value_unsafe: v, _marker: marker::PhantomData }
+                $System { value_unsafe: v, _marker: PhantomData }
+            }
+        }
+
+        impl<V, U> $System<V, U>
+        where
+            Length<U>: ArrayLength<isize>,
+            U: TypeArray + Len + ToGA<Output = GenericArray<isize, Length<U>>>,
+        {
+            /// Format just the units of this type.
+            #[inline]
+            fn fmt_units(f: &mut fmt::Formatter) -> Result<(), fmt::Error>
+            {
+                let exponents = U::to_ga();
+                let print_tokens = [$($print_as),+];
+
+                fn write_unit(f: &mut fmt::Formatter, exp: isize, token: &str) -> Result<(), fmt::Error> {
+                    if exp == 1 {
+                        write!(f, "{}", token)
+                    } else {
+                        write!(f, "{}^{}", token, exp)
+                    }
+                };
+
+                let mut units = exponents.into_iter()
+                    .zip(print_tokens.iter()).filter(|(exp, _)| *exp != 0);
+                if let Some((exp, token)) = units.next() {
+                    write_unit(f, exp, token)?;
+                }
+                for (exp, token) in units {
+                    write!(f, "*")?;
+                    write_unit(f, exp, token)?;
+                }
+                Ok(())
+            }
+
+            /// Output the units of this type in the same format as in the
+            /// formatting traits.
+            #[inline]
+            pub fn to_string() -> String {
+                struct Displayer<U2>(PhantomData<U2>);
+                impl<U2> fmt::Display for Displayer<U2>
+                where
+                    Length<U2>: ArrayLength<isize>,
+                    U2: TypeArray + Len + ToGA<Output = GenericArray<isize, Length<U2>>>,
+                {
+                    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
+                    {
+                        <$System<f32, U2>>::fmt_units(f)
+                    }
+                }
+
+                format!("{}", Displayer::<U>(PhantomData))
             }
         }
 
@@ -977,33 +1029,10 @@ macro_rules! __make_units_internal {
         {
             fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error>
             {
-                let exponents = U::to_ga();
-                let print_tokens = [$($print_as),*];
-
-                let mut first = true;
-
                 self.value_unsafe.fmt(f)?;
-
-                for (exp, token) in
-                    exponents.into_iter()
-                    .zip(print_tokens.iter())
-                {
-                    if first {
-                        if exp != 0 {
-                            first = false;
-                            write!(f, " ")?;
-                        }
-                    } else if exp != 0 {
-                        write!(f, "*")?;
-                    }
-
-                    match exp {
-                        0 => (),
-                        1 => write!(f, "{}", token)?,
-                        _ => {
-                            write!(f, "{}^{}", token, exp)?
-                        },
-                    }
+                if U::to_ga().iter().any(|&exp| exp != 0) {
+                    write!(f, " ")?;
+                    Self::fmt_units(f)?;
                 }
                 Ok(())
             }
@@ -1185,7 +1214,7 @@ macro_rules! impl_rand {
         #[derive(Clone, Copy, Debug)]
         pub struct MyUniformSampler<V: SampleUniform, U> {
             inner: V::Sampler,
-            _marker: marker::PhantomData<U>,
+            _marker: PhantomData<U>,
         }
         impl<V: SampleUniform, U> UniformSampler for MyUniformSampler<V, U> {
             type X = $System<V, U>;
@@ -1199,7 +1228,7 @@ macro_rules! impl_rand {
                         low.borrow().value_unsafe(),
                         high.borrow().value_unsafe(),
                     ),
-                    _marker: marker::PhantomData,
+                    _marker: PhantomData,
                 }
             }
             fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
@@ -1251,7 +1280,7 @@ macro_rules! impl_serde {
                 let value_unsafe = V::deserialize(deserializer)?;
                 Ok($System {
                     value_unsafe,
-                    _marker: marker::PhantomData,
+                    _marker: PhantomData,
                 })
             }
         }
@@ -1292,7 +1321,7 @@ macro_rules! impl_clapme {
             fn from_clap(name: &str, matches: &::clapme::clap::ArgMatches) -> Option<Self> {
                 V::from_clap(name, matches).map(|v| $System {
                     value_unsafe: v,
-                    _marker: marker::PhantomData,
+                    _marker: PhantomData,
                 })
             }
             fn requires_flags(name: &str) -> Vec<String> {
@@ -1319,15 +1348,15 @@ macro_rules! impl_auto_args {
                 let v = V::parse_internal(key, args)?;
                 Ok($System {
                     value_unsafe: v,
-                    _marker: marker::PhantomData,
+                    _marker: PhantomData,
                 })
             }
             const REQUIRES_INPUT: bool = true;
             fn tiny_help_message(key: &str) -> String {
                 if key == "" {
-                    "FLOAT".to_string()
+                    format!("FLOAT in units {}", $System::to_string())
                 } else {
-                    format!("{} FLOAT", key)
+                    format!("{} FLOAT in units {}", key, $System::to_string())
                 }
             }
         }

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -246,7 +246,7 @@ macro_rules! make_units {
                     } else {
                         write!(f, "{}^{}", token, exp)
                     }
-                };
+                }
 
                 let mut units = exponents.into_iter()
                     .zip(print_tokens.iter()).filter(|(exp, _)| *exp != 0);
@@ -1340,7 +1340,11 @@ macro_rules! impl_clapme {
 #[macro_export]
 macro_rules! impl_auto_args {
     ($System:ident) => {
-        impl<V: auto_args::AutoArgs, U> auto_args::AutoArgs for $System<V, U> {
+        impl<V: auto_args::AutoArgs, U> auto_args::AutoArgs for $System<V, U>
+        where
+            Length<U>: ArrayLength<isize>,
+            U: TypeArray + Len + ToGA<Output = GenericArray<isize, Length<U>>>,
+        {
             fn parse_internal(
                 key: &str,
                 args: &mut Vec<std::ffi::OsString>,
@@ -1354,9 +1358,9 @@ macro_rules! impl_auto_args {
             const REQUIRES_INPUT: bool = true;
             fn tiny_help_message(key: &str) -> String {
                 if key == "" {
-                    format!("FLOAT in units {}", $System::to_string())
+                    format!("FLOAT in units {}", <$System<V, U>>::to_string())
                 } else {
-                    format!("{} FLOAT in units {}", key, $System::to_string())
+                    format!("{} FLOAT in units {}", key, <$System<V, U>>::to_string())
                 }
             }
         }

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 extern crate dimensioned as dim;
 
 use dim::si::{self, f64consts::*};

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,0 +1,15 @@
+extern crate dimensioned as dim;
+
+use dim::si::{self, f64consts::*};
+
+#[test]
+fn formatting() {
+    assert_eq!(<si::Unitless<f32>>::to_string(), "");
+    assert_eq!(format!("{}", 3.5 * ONE), "3.5");
+
+    assert_eq!(<si::Second<f32>>::to_string(), "s");
+    assert_eq!(format!("{}", 3.5 * S), "3.5 s");
+
+    assert_eq!(<si::Newton<f32>>::to_string(), "m*kg*s^-2");
+    assert_eq!(format!("{}", 3.5 * N), "3.5 m*kg*s^-2");
+}


### PR DESCRIPTION
This formats the units in the same way as the formatting traits, but
does not require a value.

It is used in the `AutoArgs` help message.