### PR TITLE
Feature: Add type aliases for dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project follows semantic versioning.
 
 ### Unpublished
 - [fixed] A compilation error with the `rand` feature.
+- [added] Added ability to more specify type signatures using the marker trait
+  names from `dimensions.rs`. Now defined in module `dimensions`.
 
 ### 0.8.0 (2019-03-13)
 - [changed] ***BREAKING*** Reduced requirement of nightly for use in `no_std`

--- a/src/make_units.rs
+++ b/src/make_units.rs
@@ -299,9 +299,16 @@ macro_rules! make_units {
             }
         }
 
-        $(#[allow(missing_docs)] pub type $Derived<V> = $System<V, inner::$Derived>;
+        $(#[allow(missing_docs)]
+          pub type $Derived<V> = $System<V, inner::$Derived>;
           $(impl<V> $crate::dimensions::$derived_dim for $Derived<V> {})*
         )*
+
+        #[allow(missing_docs)]
+        pub mod dimensions {
+            $($(#[allow(missing_docs)]pub type $base_dim<V> = super::$Unit<V>;)*)+
+            $($(#[allow(missing_docs)]pub type $derived_dim<V> = super::$Derived<V>;)*)*
+        }
 
         // --------------------------------------------------------------------------------
         // Define consts

--- a/tests/dimensions.rs
+++ b/tests/dimensions.rs
@@ -1,0 +1,18 @@
+extern crate dimensioned as dim;
+
+use dim::si::dimensions::{Length, Time, Velocity};
+use dim::si::{Meter, MeterPerSecond, Second};
+
+// A simple test case to exercise the `dimensions` module type aliases.
+
+#[test]
+fn units() {
+    fn calc_velocity(distance: Length<i64>, time: Time<i64>) -> Velocity<i64> {
+        distance / time
+    }
+
+    assert_eq!(
+        calc_velocity(Meter::new(10), Second::new(2)),
+        MeterPerSecond::new(5)
+    );
+}


### PR DESCRIPTION
While I recognize this is somewhat redundant, in that a user could achieve the same thing using the units eg: `si::Meter`

I suspect in many areas the ability to use terms like `Length`, `Area`, and `Volume` could be beneficial.

https://github.com/paholg/dimensioned/issues/33