### PR TITLE
Allow `serde` without `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ Never again should you need to specify units in a comment!"""
   default = ["std"]
   oibit = []
   spec = []
-  std = []
+  std = [ "serde?/std" ]
   nightly = []
   test = [ "approx", "clapme", "serde", "serde_test", "rand"]
 
@@ -35,7 +35,7 @@ Never again should you need to specify units in a comment!"""
   auto-args = { version = "0.2.4", optional = true }
   generic-array = "0.14.0"
   num-traits = { version = "0.2.5", default-features = false }
-  serde = { version = "1.0.0", optional = true }
+  serde = { version = "1.0.0", optional = true, default-features = false }
   serde_test = { version = "1.0.0", optional = true }
   rand = { version = "0.8.5", optional = true }
   typenum = "1.6.0"


### PR DESCRIPTION
The `serde` crate supports building `no_std`, but `dimensioned` needs to request it without default features.