### PR TITLE
Fix formatting of constant tables

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -118,6 +118,12 @@ Following, we list all of the [base units](#base-units), [derived units](#derive
 }
 
 impl fmt::Display for System {
+    // As of 1.66, Clippy lints on `"{}", d` instead of `"{d}"`.
+    // However, this behavior is only available as of 1.58-
+    // which postdates the 2021 edition (launched in 1.56).
+    //
+    // Ignore the lint, to maintain a lower minimum supported Rust version.
+    #[allow(clippy::uninlined_format_args)]
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         writeln!(f, "/**\n{}\n", self.doc_prelude)?;
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -86,7 +86,6 @@ Following, we list all of the [base units](#base-units), [derived units](#derive
         writeln!(f, "Name | Constant | Value | Unit | Dimension")?;
         writeln!(f, "---|---|---|---|---")?;
         for b in &self.base {
-            let mut newline = false;
             for c in self.constants.iter().filter(|c| c.unit == b.name) {
                 writeln!(
                     f,
@@ -97,16 +96,10 @@ Following, we list all of the [base units](#base-units), [derived units](#derive
                     c.unit,
                     b.dim
                 )?;
-
-                newline = true;
-            }
-            if newline {
-                writeln!(f, "|")?;
             }
         }
 
         for d in &self.derived {
-            let mut newline = false;
             for c in self.constants.iter().filter(|c| c.unit == d.name) {
                 writeln!(
                     f,
@@ -117,10 +110,6 @@ Following, we list all of the [base units](#base-units), [derived units](#derive
                     c.unit,
                     d.dim
                 )?;
-                newline = true;
-            }
-            if newline {
-                writeln!(f, "|")?;
             }
         }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -582,11 +582,8 @@ mod constant_conversion {{
             .chain(s.constants.iter().map(|c| c.constant))
             .collect();
         for s2 in systems.iter().filter(|s2| s2.name != s.name) {
-            if s.from.iter().any(|&f| f == s2.name) && s2.from.iter().any(|&f| f == s.name) {
-                for c in constants1
-                    .iter()
-                    .filter(|&c| !s.refl_blacklist.iter().any(|b| c == b))
-                {
+            if s.from.contains(s2.name) && s2.from.contains(s.name) {
+                for c in constants1.iter().filter(|&c| !s.refl_blacklist.contains(c)) {
                     write!(f, "
     #[test]
     #[allow(non_snake_case)]


### PR DESCRIPTION
The `newline` code removed here generated an extra `|` character at the break between constants-for-base-units and constants-for-derived-units. This corrupted the display in the rendered table; all the derived-unit constants were not rendered into the table, but rendered as text.

Don't print the extra `|`. With this, all the constants show up in one table.

Before:

![image](https://github.com/user-attachments/assets/127092e3-59fa-4d91-b220-5a2dc116a60c)

After:

![image](https://github.com/user-attachments/assets/eda8b8db-16b8-43bf-8890-292cbd0b90b4)
